### PR TITLE
Improvements to generic compilation scripts

### DIFF
--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -64,7 +64,7 @@ if [ "$cmplr" == "mpt" ] || [ "$cmplr" == "mpt_debug" ] || [ "$cmplr" == "mpt_pr
   if [ "$list" == 'yes' ] ; then optc="$optc -list"; fi
 
   # omp options
-  if [ "$omp_mod" == 'yes' ] ; then optc="$optc -openmp"; optl="$optl -openmp"; fi
+  optomp="-openmp"
 
   # optimized options
   if [ -z "$(echo $cmplr | grep debug)" ] ; then
@@ -145,14 +145,10 @@ if [ "$cmplr" == "intel" ]          || [ "$cmplr" == "intel_debug" ]    || [ "$c
   if [ "$list" == 'yes' ] ; then optc="$optc -list"; fi
 
   # omp options
-  if [ "$omp_mod" == 'yes' ] ; then 
-    if [ "$cmplr" == "hera" ] ; then
-      optc="$optc -qopenmp"
-      optl="$optl -qopenmp"
-    else
-      optc="$optc -openmp" 
-      optl="$optl -openmp" 
-    fi
+  if [ "$cmplr" == "hera" ] ; then
+     optomp="-qopenmp"
+  else
+     optomp="-openmp"
   fi
 
   # optimized options
@@ -219,7 +215,7 @@ if [ "$cmplr" == "gnu" ] || [ "$cmplr" == "gnu_debug" ] || [ "$cmplr" == "gnu_pr
   optl='-o $prog -g'
 
   # omp options
-  if [ "$omp_mod" == 'yes' ] ; then optc="$optc -fopenmp"; optl="$optl -fopenmp"; fi
+  optomp='-fopenmp'
 
   # optimized options
   if [ -z "$(echo $cmplr | grep debug)" ] ; then
@@ -286,7 +282,7 @@ if [ "$cmplr" == "pgi" ] || [ "$cmplr" == "pgi_debug" ] || [ "$cmplr" == "pgi_pr
   if [ "$list" == 'yes' ] ; then optc="$optc -Mlist"; fi
 
   # omp options
-  if [ "$omp_mod" == 'yes' ] ; then optc="$optc -mp"; optl="$optl -mp";  fi
+  optomp="-mp"
 
   # optimized options
   if [ -z "$(echo $cmplr | grep debug)" ] ; then
@@ -340,16 +336,7 @@ if [ "$cmplr" == "ukmo_cray" ] || [ "$cmplr" == "ukmo_cray_debug" ] || \
   if [ "$list" == 'yes' ] ; then optc="$optc -hlist=a"; fi
 
   # omp options
-  if [ "$omp_mod" = 'yes' ] ; then
-    optc="$optc -h omp"
-    optl="$optl -h omp"
-  else
-    # by default, OMP is enabled on Cray ftn:
-    optc="$optc -h noomp"
-
-    # ... but don't disable at link stage as is currently needed by SCRIP
-    #optl="$optl -h noomp"
-  fi
+  optomp="-h omp"
 
   # optimized options
   if [ -z "$(echo $cmplr | grep debug)" ] ; then

--- a/model/bin/cmplr.env
+++ b/model/bin/cmplr.env
@@ -22,13 +22,19 @@
 #                                                                             #
 #  - template files comp.tmpl and link.tmpl will be used to create the        #
 #    comp and link file based on the following environment variables :        # 
-#    $optc, $optl, $comp_seq and $comp_mpi                                    #
+#    $optc, $optl, $comp_seq, $comp_mpi, $optomp, $err_pattern, $warn_pattern #
 #                                                                             #
 #                                                                             #
 #                                                      M. Accensi             #
 #                                                      August   2018          #
 # --------------------------------------------------------------------------- #
 
+
+## Set some defaults (can be overriden by individual compiler sections)
+
+# grep pattern for errors/warnings in compiler output:
+err_pattern='error'
+warn_pattern='warn'
 
 # disable listing done by the compiler
 list='no'
@@ -326,6 +332,9 @@ if [ "$cmplr" == "ukmo_cray" ] || [ "$cmplr" == "ukmo_cray_debug" ] || \
   comp_seq='ftn'
   comp_mpi='ftn'
 
+  # cray compiler output needs more specific err/warn search patterns:
+  err_pattern='crayftn: error'
+  warn_pattern='crayftn: warn'
   # OPTIONS - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   # common options
@@ -360,21 +369,3 @@ if [ "$cmplr" == "ukmo_cray" ] || [ "$cmplr" == "ukmo_cray_debug" ] || \
   # system-dependant options
   # N/A
 fi
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/model/bin/comp.tmpl
+++ b/model/bin/comp.tmpl
@@ -91,6 +91,11 @@
   opt="$opt $ESMF_F90COMPILEPATHS"
   opt="$opt $EXTRA_COMP_OPTIONS"
 
+  # OMP support
+  if [ "$omp_mod" = 'yes' ] ; then
+    opt="$opt <optomp>"
+  fi
+
 # 2.b Compile - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
   $comp $opt $name.$fext 1> $name.out 2> $name.err
@@ -154,6 +159,7 @@
     cat $name.err       >> $name.l 2> /dev/null
     echo '------------' >> $name.l
   fi
+
   # remove empty warning and error files
   # find . -name "*.out" -or -name "*.err" -empty -delete
 

--- a/model/bin/comp.tmpl
+++ b/model/bin/comp.tmpl
@@ -114,8 +114,8 @@
 
   if [ -s $name.err ]
   then
-    nr_err="$(grep -i error $name.err | wc -l | awk '{ print $1 }')"
-    nr_war="$(grep -i warning $name.err | wc -l | awk '{ print $1 }')"
+    nr_err="$(grep -i '<err_pattern>' $name.err | wc -l | awk '{ print $1 }')"
+    nr_war="$(grep -i '<warn_pattern>' $name.err | wc -l | awk '{ print $1 }')"
   else
     if [ "$OK" != '0' ]
     then

--- a/model/bin/link.tmpl
+++ b/model/bin/link.tmpl
@@ -133,6 +133,11 @@
     fi
   fi
 
+  # OMP support
+  if [ "$omp_mod" = 'yes' ] ; then
+    opt="$opt <optomp>"
+  fi
+
   opt="$opt $EXTRA_LINK_OPTIONS"
 
 # 3.b Link - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -

--- a/model/bin/w3_setup
+++ b/model/bin/w3_setup
@@ -423,7 +423,7 @@ then
        [ "$cmplr" == "ukmo_cray" ] || [ "$cmplr" == "ukmo_cray_debug" ]             || \
        [ "$cmplr" == "ukmo_cray_gnu" ] || [ "$cmplr" == "ukmo_cray_gnu_debug" ]; then
      source $path_b/cmplr.env
-     sed -e "s/<optc>/$optc/" -e "s/<comp_seq>/$comp_seq/" -e "s/<comp_mpi>/$comp_mpi/" $path_b/comp.tmpl > $path_b/comp
+     sed -e "s/<optc>/$optc/" -e "s/<comp_seq>/$comp_seq/" -e "s/<comp_mpi>/$comp_mpi/" -e "s/<optomp>/$optomp/" $path_b/comp.tmpl > $path_b/comp
      echo "      sed $path_b/comp.tmpl => $path_b/comp"
   else
     errmsg "$path_b/comp.$cmplr not found"
@@ -449,7 +449,7 @@ then
        [ "$cmplr" == "ukmo_cray" ] || [ "$cmplr" == "ukmo_cray_debug" ]             || \
        [ "$cmplr" == "ukmo_cray_gnu" ] || [ "$cmplr" == "ukmo_cray_gnu_debug" ]; then
      source $path_b/cmplr.env
-     sed -e "s/<optl>/$optl/" -e "s/<comp_seq>/$comp_seq/" -e "s/<comp_mpi>/$comp_mpi/" $path_b/link.tmpl > $path_b/link
+     sed -e "s/<optl>/$optl/" -e "s/<comp_seq>/$comp_seq/" -e "s/<comp_mpi>/$comp_mpi/" -e "s/<optomp>/$optomp/" $path_b/link.tmpl > $path_b/link
     echo "      sed $path_b/link.tmpl => $path_b/link"
   else
     errmsg "$path_b/link.$cmplr not found"

--- a/model/bin/w3_setup
+++ b/model/bin/w3_setup
@@ -423,7 +423,7 @@ then
        [ "$cmplr" == "ukmo_cray" ] || [ "$cmplr" == "ukmo_cray_debug" ]             || \
        [ "$cmplr" == "ukmo_cray_gnu" ] || [ "$cmplr" == "ukmo_cray_gnu_debug" ]; then
      source $path_b/cmplr.env
-     sed -e "s/<optc>/$optc/" -e "s/<comp_seq>/$comp_seq/" -e "s/<comp_mpi>/$comp_mpi/" -e "s/<optomp>/$optomp/" $path_b/comp.tmpl > $path_b/comp
+     sed -e "s/<optc>/$optc/" -e "s/<comp_seq>/$comp_seq/" -e "s/<comp_mpi>/$comp_mpi/" -e "s/<optomp>/$optomp/" -e "s/<err_pattern>/$err_pattern/" -e "s/<warn_pattern>/$warn_pattern/" $path_b/comp.tmpl > $path_b/comp
      echo "      sed $path_b/comp.tmpl => $path_b/comp"
   else
     errmsg "$path_b/comp.$cmplr not found"


### PR DESCRIPTION
Updates to the generic compilation scripts (`cmplr.env`, `comp.tmpl` and `link.tmpl`) and `w3_setup` to allow:

1. Correct propagation of the OMP compiler flag settings  (cb01247)
2. Configurabilty of search pattern used for grepping errors/warnings from the compiler output (
46ff3ef)