### PR TITLE
MPI/OMP hybrid thread safe MPI initialization 

### DIFF
--- a/model/ftn/ww3_multi.ftn
+++ b/model/ftn/ww3_multi.ftn
@@ -92,7 +92,7 @@
       INTEGER, ALLOCATABLE :: TEND(:,:)
       LOGICAL              :: FLGNML
 !/MPI      INTEGER              :: IERR_MPI
-!/MPI      LOGICAL              :: FLHybr = .FALSE.
+!/MPI      LOGICAL              :: FLHYBR = .FALSE.
 !/OMPH      INTEGER              :: THRLEV
 !/
 !/ ------------------------------------------------------------------- /
@@ -101,9 +101,9 @@
 !
 ! 0.b MPI environment: Here, we use MPI_COMM_WORLD
 !
-!/OMPH      FLHybr = .TRUE.
+!/OMPH      FLHYBR = .TRUE.
 !/OMPH      ! For hybrid MPI-OpenMP specify required thread level:
-!/OMPH      IF( FLHybr ) THEN
+!/OMPH      IF( FLHYBR ) THEN
 !/OMPH         CALL MPI_INIT_THREAD(MPI_THREAD_FUNNELED, THRLEV, IERR_MPI)
 !/OMPH      ELSE
 !/MPI      CALL MPI_INIT      ( IERR_MPI )

--- a/model/ftn/ww3_multi.ftn
+++ b/model/ftn/ww3_multi.ftn
@@ -92,6 +92,8 @@
       INTEGER, ALLOCATABLE :: TEND(:,:)
       LOGICAL              :: FLGNML
 !/MPI      INTEGER              :: IERR_MPI
+!/MPI      LOGICAL              :: FLHybr = .FALSE.
+!/OMPH      INTEGER              :: THRLEV
 !/
 !/ ------------------------------------------------------------------- /
 ! 0.  Initialization necessary for driver
@@ -99,7 +101,13 @@
 !
 ! 0.b MPI environment: Here, we use MPI_COMM_WORLD
 !
+!/OMPH      FLHybr = .TRUE.
+!/OMPH      ! For hybrid MPI-OpenMP specify required thread level:
+!/OMPH      IF( FLHybr ) THEN
+!/OMPH         CALL MPI_INIT_THREAD(MPI_THREAD_FUNNELED, THRLEV, IERR_MPI)
+!/OMPH      ELSE
 !/MPI      CALL MPI_INIT      ( IERR_MPI )
+!/OMPH      ENDIF
 !/MPI      MPI_COMM = MPI_COMM_WORLD
 !/MPI      CALL MPI_COMM_SIZE ( MPI_COMM, NMPROC, IERR_MPI )
 !/MPI      CALL MPI_COMM_RANK ( MPI_COMM, IMPROC, IERR_MPI )
@@ -108,6 +116,8 @@
 ! 0.c Identifying output to "screen" unit
 !
       IF ( IMPROC .EQ. NMPSCR ) WRITE (*,900)
+!/OMPH      IF ( IMPROC .EQ. NMPSCR ) WRITE (*,905) &
+!/OMPH                                        MPI_THREAD_FUNNELED, THRLEV
 !
 !/ ------------------------------------------------------------------- /
 ! 1.  Initialization of all wave models / grids
@@ -167,6 +177,9 @@
 !
   900 FORMAT (/15X,'     *** WAVEWATCH III Multi-grid shell ***    '/ &
                15X,'================================================='/)
+!/OMPH  905 FORMAT ( '  Hybrid MPI/OMP thread support level:'/        &
+!/OMPH               '     Requested: ', I2/                          &
+!/OMPH               '      Provided: ', I2/ )
 !
   999 FORMAT(//'  End of program '/                                   &
                ' ========================================'/           &

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -338,7 +338,7 @@
                              FLLST_ALL(-7:8)
       LOGICAL             :: DEBUG_NCC = .FALSE.
 !/NCC      LOGICAL             :: CFLAG(10) 
-!/MPI      LOGICAL             :: FLHybr = .FALSE.
+!/MPI      LOGICAL             :: FLHYBR = .FALSE.
 !/OMPH      INTEGER             :: THRLEV
 !/OASIS      LOGICAL             :: L_MASTER    
 !
@@ -400,14 +400,14 @@
 !/SHRD      NAPROC = 1
 !/SHRD      IAPROC = 1
 !
-!/OMPH      FLHybr = .TRUE.
+!/OMPH      FLHYBR = .TRUE.
 
 !/OASIS IF (OASISED.EQ.1) THEN
 !/OASIS   CALL CPL_OASIS_INIT(MPI_COMM)
 !/OASIS ELSE
 !/DEBUGINIT      write(740+IAPROC,*), 'Before MPI_INIT, ww3_shel'
 !/OMPH       ! For hybrid MPI-OpenMP specify required thread level. JGLi06Sep2019
-!/OMPH       IF( FLHybr ) THEN
+!/OMPH       IF( FLHYBR ) THEN
 !/OMPH         CALL MPI_INIT_THREAD( MPI_THREAD_FUNNELED, THRLEV, IERR_MPI)
 !/OMPH       ELSE
 !/MPI      CALL MPI_INIT      ( IERR_MPI )

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -338,6 +338,8 @@
                              FLLST_ALL(-7:8)
       LOGICAL             :: DEBUG_NCC = .FALSE.
 !/NCC      LOGICAL             :: CFLAG(10) 
+!/MPI      LOGICAL             :: FLHybr = .FALSE.
+!/OMPH      INTEGER             :: THRLEV
 !/OASIS      LOGICAL             :: L_MASTER    
 !
 !/
@@ -398,11 +400,18 @@
 !/SHRD      NAPROC = 1
 !/SHRD      IAPROC = 1
 !
+!/OMPH      FLHybr = .TRUE.
+
 !/OASIS IF (OASISED.EQ.1) THEN
 !/OASIS   CALL CPL_OASIS_INIT(MPI_COMM)
 !/OASIS ELSE
 !/DEBUGINIT      write(740+IAPROC,*), 'Before MPI_INIT, ww3_shel'
+!/OMPH       ! For hybrid MPI-OpenMP specify required thread level. JGLi06Sep2019
+!/OMPH       IF( FLHybr ) THEN
+!/OMPH         CALL MPI_INIT_THREAD( MPI_THREAD_FUNNELED, THRLEV, IERR_MPI)
+!/OMPH       ELSE
 !/MPI      CALL MPI_INIT      ( IERR_MPI )
+!/OMPH       ENDIF
 !/DEBUGINIT      write(740+IAPROC,*), 'After MPI_INIT, ww3_shel'
 !/MPI      MPI_COMM = MPI_COMM_WORLD
 !/OASIS END IF
@@ -490,6 +499,8 @@
       ELSE
         NDSEN  = -1
       END IF
+!/OMPH      IF ( IAPROC .EQ. NAPOUT ) WRITE (NDSO,905) &
+!/OMPH                                        MPI_THREAD_FUNNELED, THRLEV
 !
 
 !
@@ -2435,6 +2446,9 @@
                15X,'==============================================='/)
   901 FORMAT ( '  Comment character is ''',A,''''/)
 !
+!/OMPH  905 FORMAT ( '  Hybrid MPI/OMP thread support level:'/        &
+!/OMPH               '     Requested: ', I2/                          &
+!/OMPH               '      Provided: ', I2/ )
   920 FORMAT (/'  Input fields : '/                                   &
                ' --------------------------------------------------')
   921 FORMAT ( '       ',A,2X,A,2X,A)


### PR DESCRIPTION
_Note: This PR was initially part of PR #3 authored by @ukmo-jianguo-li ._ 

When calling MPI libary routines in a thread (OMP) enabled program, the MPI execution environment should be initialised with `MPI_INIT_THREAD` and a suitable thread support level. See [MPI_Init_thread.3.php](https://www.open-mpi.org/doc/v3.0/man3/MPI_Init_thread.3.php) for details.

For **ww3_shel** and **ww3_multi** the thread support level has set to be "Funneled", which means that only the main thread (the one that called `MPI_INIT_THREAD`) will make the MPI call. 

Whilst there are (I believe) no MPI calls being made inside an OMP loop in the WW3 code at the moment, it is still a good idea to still use `MPI_INIT_THREAD` in hybrid code for the following reasons:
 
1. If the MPI library encounters threading (e.g. by working out if the OpenMP runtime is active) then, in the absence of any other information, it may well take the “least-risk” options wrt how it should manage things. This may well be the lowest performance option too.

2. Compilers can do weird things w.r.t. optimizations and providing a thread level might allow better optimization of the code.

3. It can also affect how the hardware/OS handles the message passing over the network, especially if you have a specialist interconnect as in HPCs.

At the Met Office we have experienced ~10% reduction in runtime when using `MPI_INIT_THREAD` compared to `MPI_INIT`; most likely due to one or more of the reasons mention above.