### PR TITLE
Added boundary checks to the SMC input files for ww3_grid

### DIFF
--- a/model/ftn/ww3_grid.ftn
+++ b/model/ftn/ww3_grid.ftn
@@ -4410,7 +4410,18 @@
 !/SMC          JS=MAX(1, IJKCel(4,ISEA)/MRFct)
 !/ARC        ENDIF
 !/ARC
-!/SMC !!Li  Minimum DMIN depth is used as well for SMC. 
+!/SMC !      Check that IX, IY are in the bound of [1,NX] and [1,NY] respec.
+!/SMC        IF ((IX+IK-1 .GT. NX) .OR. (IX .LE. 0)) THEN
+!/SMC             WRITE (NDSE,1014) ISEA, IX, IX+IK-1, NX
+!/SMC             CALL EXTCDE(65)
+!/SMC        END IF
+!/SMC 
+!/SMC        IF ((IY+JS-1 .GT. NY) .OR. (IY .LE. 0)) THEN
+!/SMC             WRITE (NDSE,1015) ISEA, IY, IY+JS-1, NY
+!/SMC             CALL EXTCDE(65)
+!/SMC        END IF
+!/SMC
+!/SMC !Li  Minimum DMIN depth is used as well for SMC. 
 !/SMC          ZB(ISEA)= - MAX( DMIN, FLOAT( IJKCel(5, ISEA) ) )
 !/SMC          MAPFS(IY:IY+JS-1,IX:IX+IK-1)  = ISEA
 !/SMC         MAPSTA(IY:IY+JS-1,IX:IX+IK-1)  = 1
@@ -5999,6 +6010,14 @@
                '     AND REPLACED WITH A STRING INDICATING THE TYPE'/ &
                '     OF GRID INDEX CLOSURE (NONE, SMPL or TRPL).'/    &
                ' *** PLEASE UPDATE YOUR GRID INPUT FILE ACCORDINGLY ***'/)
+!
+ 1014 FORMAT (/' *** WAVEWATCH-III ERROR IN W3GRID :'/                &
+               '   SMC CELL LONGITUDE RANGE OUTSIDE BASE GRID RANGE:'/&
+               '   ISEA =', I6, '; IX =', I4, ':', I4,'; NX =', I4/)
+!
+ 1015 FORMAT (/' *** WAVEWATCH-III ERROR IN W3GRID :'/                &
+               '   SMC CELL LATITUDE RANGE OUTSIDE BASE GRID RANGE: '/&
+               '   ISEA =', I6, '; IY =', I4, ':', I4,'; NY =', I4/)
 !
  1020 FORMAT (/' *** WAVEWATCH-III ERROR IN W3GRID :'/                &
                '     SOURCE TERMS REQUESTED BUT NOT SELECTED'/)


### PR DESCRIPTION
Added boundary checks to the SMC grid input files for ww3_grid, to ensure they comply with the limits of the nameslist.

Regrestion tests complete:
- ww3_tp2.10 [No changes to results]
- ww3_tp2.16 [No changes to results]



 