### PR TITLE
Changes for ticket #238: fix coupling condition

### DIFF
--- a/model/ftn/w3wavemd.ftn
+++ b/model/ftn/w3wavemd.ftn
@@ -80,6 +80,7 @@
 !/                  (M. Accensi & F. Ardhuin, IFREMER)
 !/    27-Aug-2015 : Update for ICEH, ICEF               ( version 5.08 )
 !/    14-Sep-2018 : Remove PALM implementation          ( version 6.06 )
+!/    30-Jul-2020 : Update oasis coupling condition     ( version 7.08 )
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -2400,7 +2401,7 @@
 !/OASIS ! Send variables to atmospheric or ocean circulation or ice model
 !/OASIS !
 !/OASIS                              IF (DTOUT(7).NE.0) THEN
-!/OASIS                                IF ( (MOD(ID_OASIS_TIME/DTOUT(7),1.0)  .LT. 1.E-7 ) .AND. &
+!/OASIS                                IF ( (MOD(ID_OASIS_TIME, NINT(DTOUT(7))) .EQ. 0) .AND. &
 !/OASIS                                     (DSEC21 (TIME00, TIME) .GT. 0.0) ) THEN
 !/OASACM                                  CALL SND_FIELDS_TO_ATMOS()
 !/OASOCM                                  CALL SND_FIELDS_TO_OCEAN()

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -54,6 +54,7 @@
 !/    04-Oct-2019 : Inline Output implementation        ( version 6.07 )
 !/                  (Roberto Padilla-Hernandez)
 !/    16-Jul-2020 : Variable coupling time step         ( version 7.08 )
+!/    30-Jul-2020 : Update oasis coupling condition     ( version 7.08 )
 !/
 !/    Copyright 2009-2012 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -1912,7 +1913,7 @@
 !/OASIS          ELSE 
 !/OASIS            ID_OASIS_TIME = DSEC21 ( TIME00 , TIME )
 !/OASIS            IF ( (DTOUT(7).NE.0) .AND.                               &
-!/OASIS                 (MOD(ID_OASIS_TIME/DTOUT(7),1.0) .LT. 1.E-7 ) .AND. &
+!/OASIS                 (MOD(ID_OASIS_TIME, NINT(DTOUT(7))) .EQ. 0) .AND.   &
 !/OASIS                 (DSEC21 (TIME, TIMEEND) .GT. 0.0)) DTTST=0.
           END IF
 !

--- a/regtests/bin/matrix_ukmo_cray
+++ b/regtests/bin/matrix_ukmo_cray
@@ -38,7 +38,7 @@
   # Set Cray compiler variant; CCE (Cray Compiler Environment) or GNU.
   # Use GNU for programs compiled with PDLIB, CCE for all others.
   comp="CCE"
-  #comp = "GNU"
+  #comp="GNU"
 
 
 # 1. Set up for compilation environemnt on Cray XC (broadwell processors)


### PR DESCRIPTION
Fix for ticket https://github.com/NOAA-EMC/WW3/issues/238

I tested the oasis coupling regtests with the gnu compiler (the modifications only affect these tests) and gives the same results as the original code. The cray compiler is working now, and when compared with the results using the gnu compiler there are some precision differences.