### PR TITLE
Double allocation error of FIELD variable [w3wavemd]

### DIFF
--- a/model/ftn/w3wavemd.ftn
+++ b/model/ftn/w3wavemd.ftn
@@ -80,7 +80,8 @@
 !/                  (M. Accensi & F. Ardhuin, IFREMER)
 !/    27-Aug-2015 : Update for ICEH, ICEF               ( version 5.08 )
 !/    14-Sep-2018 : Remove PALM implementation          ( version 6.06 )
-!/    15-Sep-2020 : Bugfix FIELD allocation             ( version 7.11 )
+!/    15-Sep-2020 : Bugfix FIELD allocation. Remove     ( version 7.11 )
+!/                  defunct OMPX switches.
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -155,7 +156,6 @@
 !       !/DIST  Id.
 !       !/MPI   Id.
 !       !/OMPG  Id.
-!       !/OMPX  Id.
 !
 !       !/PR1   First order propagation schemes.
 !       !/PR2   ULTIMATE QUICKEST scheme.
@@ -457,8 +457,7 @@
       LOGICAL                 :: FLACT, FLZERO, FLFRST, FLMAP, TSTAMP,&
                                  SKIP_O, FLAG_O, FLDDIR, READBC,      &
                                  FLAG0 = .FALSE., FLOUTG, FLPFLD,     &
-                                 FLPART, LOCAL, FLOUTG2,              &
-                                 FLOMP = .FALSE.
+                                 FLPART, LOCAL, FLOUTG2
 !
 !Li   Logical variable to control regular gird lines in conflict with SMC option.
 !AR   SMC option is in conflict with lofical variables for regular grid ... chicken ... egg ... stuff 
@@ -497,8 +496,6 @@
 !/ARC        ARCTIC = .TRUE.
 !
 ! 0.a Set pointers to data structure
-!
-!/OMPX      FLOMP  = .TRUE.
 !
 !/COU      SCREEN   =  333
 !
@@ -577,7 +574,7 @@
           FCUT  = SIG(NK) * TPIINV
         END IF
 !
-      IF( RGLGRD .AND. .NOT. FLOMP ) ALLOCATE ( FIELD(1-NY:NY*(NX+2)) )
+      IF( RGLGRD ) ALLOCATE ( FIELD(1-NY:NY*(NX+2)) )
 !
 !/SMC !!Li   Otherwise use sea point only field
 !/SMC       ALLOCATE ( FIELD(NCel) )

--- a/model/ftn/w3wavemd.ftn
+++ b/model/ftn/w3wavemd.ftn
@@ -80,6 +80,7 @@
 !/                  (M. Accensi & F. Ardhuin, IFREMER)
 !/    27-Aug-2015 : Update for ICEH, ICEF               ( version 5.08 )
 !/    14-Sep-2018 : Remove PALM implementation          ( version 6.06 )
+!/    15-Sep-2020 : Bugfix FIELD allocation             ( version 7.11 )
 !/
 !/    Copyright 2009-2014 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -576,7 +577,6 @@
           FCUT  = SIG(NK) * TPIINV
         END IF
 !
-!!Li  ALLOCATE ( FIELD(1-NY:NY*(NX+2)) )
       IF( RGLGRD .AND. .NOT. FLOMP ) ALLOCATE ( FIELD(1-NY:NY*(NX+2)) )
 !
 !/SMC !!Li   Otherwise use sea point only field
@@ -1728,17 +1728,11 @@
 !/MPI         CALL MPI_STARTALL (NRQSG1, IRQSG1(1,2), IERR_MPI)
 !/MPI       END IF
 !
-!!/OMPX/!$OMP PARALLEL PRIVATE (ISPEC,FIELD)
-!
 !/DEBUGRUN        WRITE(740+IAPROC,*) 'W3WAVE, step 6.14'
 !/DEBUGRUN        FLUSH(740+IAPROC)
-
-            IF ( FLOMP ) ALLOCATE ( FIELD(1-NY:NY*(NX+2)) )
 !
 ! Initialize FIELD variable 
              FIELD = 0.
-!
-!!/OMPX/!$OMP DO SCHEDULE (DYNAMIC,1)
 !
             DO ISPEC=1, NSPEC
               IF ( IAPPRO(ISPEC) .EQ. IAPROC ) THEN
@@ -1785,14 +1779,7 @@
 !/MEMCHECK       write(740+IAPROC,*) 'memcheck_____:', 'WW3_WAVE TIME LOOP 17'
 !/MEMCHECK       call getMallocInfo(mallinfos)
 !/MEMCHECK       call printMallInfo(IAPROC,mallInfos)
-
-
-!!/OMPX/!$OMP END DO
-
-              IF ( FLOMP ) DEALLOCATE ( FIELD )
-
-!!/OMPX/!$OMP END PARALLEL
-
+!
 !Li   Initialise IK IX IY in case ARC option is not used to avoid warnings.
               IK=1
               IX=1
@@ -2609,8 +2596,7 @@
 
       IF ( IAPROC .EQ. NAPLOG ) WRITE (NDSO,902)
 !
-      IF ( .NOT. FLOMP ) DEALLOCATE ( FIELD )
-!
+      DEALLOCATE(FIELD)
       DEALLOCATE(TAUWX, TAUWY)
 !
 !/MEMCHECK       write(740+IAPROC,*) 'memcheck_____:', 'WW3_WAVE END W3WAVE'


### PR DESCRIPTION
Relates to issue https://github.com/NOAA-EMC/WW3/issues/252

When running on an `SMC` grid using `SHRD` and `OMPG`/`OMPX` switches, `ww3_shel` crashes in the `w3wavemd` module due to an array being allocated twice.

The issue arises due to some incorrect logic relating to the allocation of the `FIELD` variable. There is a defunct `OMP PARALLEL` section starting at line 1731 that was disabled some time ago in PR https://github.com/NOAA-EMC/WW3/pull/160 due to it causing bit-for-bit differences. However, the logic for allocating the FILED array as a private variable inside the parallel section (rather than a shared variable outside) was left in - and this logic is incorrect. When the model is run with a combination of `SMC` and `OMPX` switches, the array is erroneously allocated twice.

The simplest solution is to keep only the initial allocation at line 580 - 583 and remove the allocation in the parallel section. Furthermore, as the `OMPX` statements are now defunct, we can remove them and the associated `FLOMP` logical. This also requires only a single `DEALLOCATE` statement.

_NOTE: If it is considered that the OMP section starting at line 1731 might be re-instated in the future, I can keep the second allocation and fix the incorrect logic._