### PR TITLE
Bf unconforming where in coupling routines

### DIFF
--- a/model/ftn/w3agcmmd.ftn
+++ b/model/ftn/w3agcmmd.ftn
@@ -100,7 +100,7 @@
 !
       USE W3OACPMD,  ONLY: ID_OASIS_TIME, IL_NB_SND, SND_FLD, CPL_OASIS_SND
       USE W3GDATMD,  ONLY: NSEAL, NSEA 
-      USE W3ADATMD,  ONLY: NSEALM, CX, CY, CHARN, HS, FP0, TWS
+      USE W3ADATMD,  ONLY: CX, CY, CHARN, HS, FP0, TWS
       USE W3ODATMD,  ONLY: UNDEF, NAPROC, IAPROC
 !
 !/ ------------------------------------------------------------------- /
@@ -109,7 +109,7 @@
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_SND
       INTEGER                          :: IB_DO
       LOGICAL                          :: LL_ACTION   
-      REAL(kind=8), DIMENSION(NSEALM)  :: TMP
+      REAL(kind=8), DIMENSION(NSEAL)   :: TMP
       INTEGER                          :: JSEA, ISEA
 !
 !----------------------------------------------------------------------
@@ -120,7 +120,7 @@
          ! Ocean sea surface current (m.s-1) (u-component)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_WSSU') THEN
-            TMP(1:NSEALM) = 0.0 
+            TMP(1:NSEAL) = 0.0 
             DO JSEA=1, NSEAL
                ISEA=IAPROC+(JSEA-1)*NAPROC
                IF(CX(ISEA) /= UNDEF) TMP(JSEA)=CX(ISEA)
@@ -132,7 +132,7 @@
          ! Ocean sea surface current (m.s-1) (v-component)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_WSSV') THEN
-            TMP(1:NSEALM) = 0.0
+            TMP(1:NSEAL) = 0.0
             DO JSEA=1, NSEAL
                 ISEA=IAPROC+(JSEA-1)*NAPROC
                 IF(CY(ISEA) /= UNDEF) TMP(JSEA)=CY(ISEA)
@@ -145,8 +145,8 @@
          ! Charnock Coefficient (-)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_ACHA') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(CHARN /= UNDEF) TMP=CHARN
+            TMP(1:NSEAL) = 0.0
+            WHERE(CHARN(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=CHARN(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -154,8 +154,8 @@
          ! Significant wave height (m)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3__AHS') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(HS /= UNDEF) TMP=HS
+            TMP(1:NSEAL) = 0.0
+            WHERE(HS(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=HS(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -163,8 +163,8 @@
          ! Peak frequency (s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3___FP') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(FP0 /= UNDEF) TMP=FP0
+            TMP(1:NSEAL) = 0.0
+            WHERE(FP0(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=FP0(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -172,8 +172,8 @@
          ! Peak period (s)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3___TP') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(FP0 /= UNDEF) TMP=1./FP0
+            TMP(1:NSEAL) = 0.0
+            WHERE(FP0(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=1./FP0(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -181,8 +181,8 @@
          ! Wind sea Mean period (s)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3__FWS') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(TWS /= UNDEF) TMP=TWS
+            TMP(1:NSEAL) = 0.0
+            WHERE(TWS(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=TWS(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF

--- a/model/ftn/w3agcmmd.ftn
+++ b/model/ftn/w3agcmmd.ftn
@@ -136,7 +136,6 @@
             DO JSEA=1, NSEAL
                 ISEA=IAPROC+(JSEA-1)*NAPROC
                 IF(CY(ISEA) /= UNDEF) TMP(JSEA)=CY(ISEA)
-                TMP(JSEA)=CY(ISEA)
             END DO
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)

--- a/model/ftn/w3agcmmd.ftn
+++ b/model/ftn/w3agcmmd.ftn
@@ -100,7 +100,7 @@
 !
       USE W3OACPMD,  ONLY: ID_OASIS_TIME, IL_NB_SND, SND_FLD, CPL_OASIS_SND
       USE W3GDATMD,  ONLY: NSEAL, NSEA 
-      USE W3ADATMD,  ONLY: CX, CY, CHARN, HS, FP0, TWS
+      USE W3ADATMD,  ONLY: NSEALM, CX, CY, CHARN, HS, FP0, TWS
       USE W3ODATMD,  ONLY: UNDEF, NAPROC, IAPROC
 !
 !/ ------------------------------------------------------------------- /
@@ -109,7 +109,7 @@
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_SND
       INTEGER                          :: IB_DO
       LOGICAL                          :: LL_ACTION   
-      REAL(kind=8), DIMENSION(NSEAL)   :: TMP
+      REAL(kind=8), DIMENSION(NSEALM)  :: TMP
       INTEGER                          :: JSEA, ISEA
 !
 !----------------------------------------------------------------------
@@ -120,7 +120,7 @@
          ! Ocean sea surface current (m.s-1) (u-component)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_WSSU') THEN
-            TMP(1:NSEAL) = 0.0 
+            TMP(1:NSEALM) = 0.0 
             DO JSEA=1, NSEAL
                ISEA=IAPROC+(JSEA-1)*NAPROC
                IF(CX(ISEA) /= UNDEF) TMP(JSEA)=CX(ISEA)
@@ -132,7 +132,7 @@
          ! Ocean sea surface current (m.s-1) (v-component)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_WSSV') THEN
-            TMP(1:NSEAL) = 0.0
+            TMP(1:NSEALM) = 0.0
             DO JSEA=1, NSEAL
                 ISEA=IAPROC+(JSEA-1)*NAPROC
                 IF(CY(ISEA) /= UNDEF) TMP(JSEA)=CY(ISEA)
@@ -145,7 +145,7 @@
          ! Charnock Coefficient (-)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_ACHA') THEN
-            TMP(1:NSEAL) = 0.0
+            TMP(1:NSEALM) = 0.0
             WHERE(CHARN /= UNDEF) TMP=CHARN
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
@@ -154,7 +154,7 @@
          ! Significant wave height (m)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3__AHS') THEN
-            TMP(1:NSEAL) = 0.0
+            TMP(1:NSEALM) = 0.0
             WHERE(HS /= UNDEF) TMP=HS
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
@@ -163,7 +163,7 @@
          ! Peak frequency (s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3___FP') THEN
-            TMP(1:NSEAL) = 0.0
+            TMP(1:NSEALM) = 0.0
             WHERE(FP0 /= UNDEF) TMP=FP0
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
@@ -172,7 +172,7 @@
          ! Peak period (s)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3___TP') THEN
-            TMP(1:NSEAL) = 0.0
+            TMP(1:NSEALM) = 0.0
             WHERE(FP0 /= UNDEF) TMP=1./FP0
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
@@ -181,7 +181,7 @@
          ! Wind sea Mean period (s)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3__FWS') THEN
-            TMP(1:NSEAL) = 0.0
+            TMP(1:NSEALM) = 0.0
             WHERE(TWS /= UNDEF) TMP=TWS
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)

--- a/model/ftn/w3igcmmd.ftn
+++ b/model/ftn/w3igcmmd.ftn
@@ -98,7 +98,7 @@
       USE W3OACPMD,  ONLY: ID_OASIS_TIME, IL_NB_SND, SND_FLD, CPL_OASIS_SND
       USE W3GDATMD,  ONLY: NSEAL, NSEA 
       USE W3WDATMD,  ONLY: ICEF
-      USE W3ADATMD,  ONLY: NSEALM, TAUICE
+      USE W3ADATMD,  ONLY: TAUICE
       USE W3ODATMD,  ONLY: UNDEF, NAPROC, IAPROC
 !
 !/ ------------------------------------------------------------------- /
@@ -107,7 +107,7 @@
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_SND
       INTEGER                          :: IB_DO, NDSO
       LOGICAL                          :: LL_ACTION   
-      REAL(kind=8), DIMENSION(NSEALM)  :: TMP
+      REAL(kind=8), DIMENSION(NSEAL)   :: TMP
       INTEGER                          :: JSEA, ISEA
 !
 !----------------------------------------------------------------------
@@ -121,7 +121,7 @@
          ! Ice floe diameters (m)
          ! ---------------------------------------------------------------------     
          CASE ('WW3_ICEF')
-            TMP(1:NSEALM) = 0.0 
+            TMP(1:NSEAL) = 0.0 
             DO JSEA=1, NSEAL
                ISEA=IAPROC+(JSEA-1)*NAPROC
                IF(ICEF(ISEA) /= UNDEF) TMP(JSEA)=ICEF(ISEA)
@@ -130,14 +130,14 @@
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
 
          CASE ('WW3_TWIX')
-            TMP(1:NSEALM) = 0.0 
-            WHERE(TAUICE(:,1) /= UNDEF) TMP(:)=TAUICE(:,1)
+            TMP(1:NSEAL) = 0.0 
+            WHERE(TAUICE(1:NSEAL,1) /= UNDEF) TMP(1:NSEAL)=TAUICE(1:NSEAL,1)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
 
          CASE ('WW3_TWIY')
-            TMP(1:NSEALM) = 0.0 
-            WHERE(TAUICE(:,2) /= UNDEF) TMP(:)=TAUICE(:,2)
+            TMP(1:NSEAL) = 0.0 
+            WHERE(TAUICE(1:NSEAL,2) /= UNDEF) TMP(1:NSEAL)=TAUICE(1:NSEAL,2)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
 

--- a/model/ftn/w3igcmmd.ftn
+++ b/model/ftn/w3igcmmd.ftn
@@ -98,7 +98,7 @@
       USE W3OACPMD,  ONLY: ID_OASIS_TIME, IL_NB_SND, SND_FLD, CPL_OASIS_SND
       USE W3GDATMD,  ONLY: NSEAL, NSEA 
       USE W3WDATMD,  ONLY: ICEF
-      USE W3ADATMD,  ONLY: TAUICE
+      USE W3ADATMD,  ONLY: NSEALM, TAUICE
       USE W3ODATMD,  ONLY: UNDEF, NAPROC, IAPROC
 !
 !/ ------------------------------------------------------------------- /
@@ -107,7 +107,7 @@
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_SND
       INTEGER                          :: IB_DO, NDSO
       LOGICAL                          :: LL_ACTION   
-      REAL(kind=8), DIMENSION(NSEAL)   :: TMP
+      REAL(kind=8), DIMENSION(NSEALM)  :: TMP
       INTEGER                          :: JSEA, ISEA
 !
 !----------------------------------------------------------------------
@@ -121,7 +121,7 @@
          ! Ice floe diameters (m)
          ! ---------------------------------------------------------------------     
          CASE ('WW3_ICEF')
-            TMP(1:NSEAL) = 0.0 
+            TMP(1:NSEALM) = 0.0 
             DO JSEA=1, NSEAL
                ISEA=IAPROC+(JSEA-1)*NAPROC
                IF(ICEF(ISEA) /= UNDEF) TMP(JSEA)=ICEF(ISEA)
@@ -130,13 +130,13 @@
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
 
          CASE ('WW3_TWIX')
-            TMP(1:NSEAL) = 0.0 
+            TMP(1:NSEALM) = 0.0 
             WHERE(TAUICE(:,1) /= UNDEF) TMP(:)=TAUICE(:,1)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
 
          CASE ('WW3_TWIY')
-            TMP(1:NSEAL) = 0.0 
+            TMP(1:NSEALM) = 0.0 
             WHERE(TAUICE(:,2) /= UNDEF) TMP(:)=TAUICE(:,2)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)

--- a/model/ftn/w3ogcmmd.ftn
+++ b/model/ftn/w3ogcmmd.ftn
@@ -108,8 +108,8 @@
 !
       USE W3OACPMD,  ONLY: ID_OASIS_TIME, IL_NB_SND, SND_FLD, CPL_OASIS_SND
       USE W3GDATMD,  ONLY: NSEAL, MAPSTA, MAPSF
-      USE W3ADATMD,  ONLY: NSEALM, HS, T0M1, THM, BHD, TAUOX, TAUOY,    &
-                           PHIOC, UBA, UBD, TAUWIX, TAUWIY, TUSX, TUSY, &
+      USE W3ADATMD,  ONLY: HS, T0M1, THM, BHD, TAUOX, TAUOY, PHIOC,    &
+                           UBA, UBD, TAUWIX, TAUWIY, TUSX, TUSY,       &
                            USSX, USSY, WLM, PHIBBL,TAUBBL, CHARN
       USE W3ODATMD,  ONLY: NAPROC, IAPROC, UNDEF
       USE CONSTANTS, ONLY: PI, DERA
@@ -126,7 +126,7 @@
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_SND
       INTEGER                          :: IB_DO
       LOGICAL                          :: LL_ACTION   
-      REAL(kind=8), DIMENSION(NSEALM)  :: TMP
+      REAL(kind=8), DIMENSION(NSEAL)   :: TMP
 !
 !----------------------------------------------------------------------
 ! * Executable part
@@ -151,8 +151,8 @@
          ! Mean wave period (tmn in s) (m0,-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_T0M1') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(T0M1 /= UNDEF) TMP=T0M1
+            TMP(1:NSEAL) = 0.0
+            WHERE(T0M1(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=T0M1(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -176,8 +176,8 @@
          ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
          ! theta : trigonometric convention ( 0 at East, 90 at North)
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_CDIR') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(THM /= UNDEF) TMP=COS(THM)
+            TMP(1:NSEAL) = 0.0
+            WHERE(THM(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=COS(THM(1:NSEAL))
             RLA_OASIS_SND(:,1) = TMP(1:NSEAL)
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -187,8 +187,8 @@
          ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
          ! theta : trigonometric convention ( 0 at East, 90 at North)
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_SDIR') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(THM /= UNDEF) TMP=SIN(THM)
+            TMP(1:NSEAL) = 0.0
+            WHERE(THM(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=SIN(THM(1:NSEAL))
             RLA_OASIS_SND(:,1) = TMP(1:NSEAL)
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -203,8 +203,8 @@
          ! Wave-ocean momentum flux (tauox in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TWOX') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(TAUOX /= UNDEF) TMP=TAUOX
+            TMP(1:NSEAL) = 0.0
+            WHERE(TAUOX(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=TAUOX(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -212,8 +212,8 @@
          ! Wave-ocean momentum flux (tauoy in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TWOY') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(TAUOY /= UNDEF) TMP=TAUOY
+            TMP(1:NSEAL) = 0.0
+            WHERE(TAUOY(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=TAUOY(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -221,8 +221,8 @@
          ! Wave-to-ocean TKE flux (phioc in W.m-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3__FOC') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(PHIOC /= UNDEF) TMP=PHIOC
+            TMP(1:NSEAL) = 0.0
+            WHERE(PHIOC(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=PHIOC(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -230,8 +230,8 @@
          ! Momentum flux due to bottom friction (taubblx in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TBBX') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(TAUBBL(:,1) /= UNDEF) TMP(:)=TAUBBL(:,1)
+            TMP(1:NSEAL) = 0.0
+            WHERE(TAUBBL(1:NSEAL,1) /= UNDEF) TMP(1:NSEAL)=TAUBBL(1:NSEAL,1)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -239,8 +239,8 @@
          ! Momentum flux due to bottom friction (taubbly in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TBBY') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(TAUBBL(:,2) /= UNDEF) TMP(:)=TAUBBL(:,2)
+            TMP(1:NSEAL) = 0.0
+            WHERE(TAUBBL(1:NSEAL,2) /= UNDEF) TMP(1:NSEAL)=TAUBBL(1:NSEAL,2)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -248,8 +248,8 @@
          ! Energy flux due to bottom friction (phibbl in W.m-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3__FBB') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(PHIBBL /= UNDEF) TMP=PHIBBL
+            TMP(1:NSEAL) = 0.0
+            WHERE(PHIBBL(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=PHIBBL(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -264,8 +264,8 @@
          ! x component of the near-bottom rms wave velocity (in m.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_UBRX') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(UBA /= UNDEF) TMP=UBA*COS(UBD)
+            TMP(1:NSEAL) = 0.0
+            WHERE(UBA(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=UBA(1:NSEAL)*COS(UBD(1:NSEAL))
             RLA_OASIS_SND(:,1) = TMP(1:NSEAL)
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -273,8 +273,8 @@
          ! y component of the near-bottom rms wave velocity (in m.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_UBRY') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(UBA /= UNDEF) TMP=UBA*SIN(UBD)
+            TMP(1:NSEAL) = 0.0
+            WHERE(UBA(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=UBA(1:NSEAL)*SIN(UBD(1:NSEAL))
             RLA_OASIS_SND(:,1) = TMP(1:NSEAL)
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -282,8 +282,8 @@
          ! Net wave-supported stress, u component (tauwix in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TAWX') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(TAUWIX /= UNDEF) TMP=TAUWIX
+            TMP(1:NSEAL) = 0.0
+            WHERE(TAUWIX(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=TAUWIX(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -291,8 +291,8 @@
          ! Net wave-supported stress, v component (tauwix in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TAWY') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(TAUWIY /= UNDEF) TMP=TAUWIY
+            TMP(1:NSEAL) = 0.0
+            WHERE(TAUWIY(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=TAUWIY(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -300,8 +300,8 @@
          ! Volume transport associated to Stokes drift, u component (tusx in m2.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TUSX') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(TUSX /= UNDEF) TMP=TUSX
+            TMP(1:NSEAL) = 0.0
+            WHERE(TUSX(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=TUSX(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -309,8 +309,8 @@
          ! Volume transport associated to Stokes drift, v component (tusy in m2.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TUSY') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(TUSY /= UNDEF) TMP=TUSY
+            TMP(1:NSEAL) = 0.0
+            WHERE(TUSY(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=TUSY(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -318,8 +318,8 @@
          ! Surface Stokes drift, u component (ussx in m.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_USSX') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(USSX /= UNDEF) TMP=USSX
+            TMP(1:NSEAL) = 0.0
+            WHERE(USSX(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=USSX(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -327,8 +327,8 @@
          ! Surface Stokes drift, v component (ussy in m.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_USSY') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(USSY /= UNDEF) TMP=USSY
+            TMP(1:NSEAL) = 0.0
+            WHERE(USSY(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=USSY(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -336,8 +336,8 @@
          ! Mean wave length (wlm in m)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3___LM') THEN
-            TMP(1:NSEALM) = 0.0
-            WHERE(WLM /= UNDEF) TMP=WLM
+            TMP(1:NSEAL) = 0.0
+            WHERE(WLM(1:NSEAL) /= UNDEF) TMP(1:NSEAL)=WLM(1:NSEAL)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF

--- a/model/ftn/w3ogcmmd.ftn
+++ b/model/ftn/w3ogcmmd.ftn
@@ -108,9 +108,9 @@
 !
       USE W3OACPMD,  ONLY: ID_OASIS_TIME, IL_NB_SND, SND_FLD, CPL_OASIS_SND
       USE W3GDATMD,  ONLY: NSEAL, MAPSTA, MAPSF
-      USE W3ADATMD,  ONLY: HS, T0M1, THM, BHD, TAUOX, TAUOY, PHIOC, UBA, UBD, &
-                           TAUWIX, TAUWIY, TUSX, TUSY, USSX, USSY, WLM, &
-                           PHIBBL,TAUBBL, CHARN
+      USE W3ADATMD,  ONLY: NSEALM, HS, T0M1, THM, BHD, TAUOX, TAUOY,    &
+                           PHIOC, UBA, UBD, TAUWIX, TAUWIY, TUSX, TUSY, &
+                           USSX, USSY, WLM, PHIBBL,TAUBBL, CHARN
       USE W3ODATMD,  ONLY: NAPROC, IAPROC, UNDEF
       USE CONSTANTS, ONLY: PI, DERA
 !
@@ -121,12 +121,12 @@
 !/ ------------------------------------------------------------------- /
 !/ Local parameters
 !/
-      INTEGER                        :: I, ISEA, IX, IY
-      INTEGER, DIMENSION(NSEAL)      :: MASK
+      INTEGER                          :: I, ISEA, IX, IY
+      INTEGER, DIMENSION(NSEAL)        :: MASK
       REAL(kind=8), DIMENSION(NSEAL,1) :: RLA_OASIS_SND
-      INTEGER                        :: IB_DO
-      LOGICAL                        :: LL_ACTION   
-      REAL(kind=8), DIMENSION(NSEAL) :: TMP
+      INTEGER                          :: IB_DO
+      LOGICAL                          :: LL_ACTION   
+      REAL(kind=8), DIMENSION(NSEALM)  :: TMP
 !
 !----------------------------------------------------------------------
 ! * Executable part
@@ -151,7 +151,7 @@
          ! Mean wave period (tmn in s) (m0,-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_T0M1') THEN
-            TMP(1:NSEAL) = 0.0
+            TMP(1:NSEALM) = 0.0
             WHERE(T0M1 /= UNDEF) TMP=T0M1
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
@@ -176,7 +176,7 @@
          ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
          ! theta : trigonometric convention ( 0 at East, 90 at North)
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_CDIR') THEN
-            TMP(1:NSEAL) = 0.0
+            TMP(1:NSEALM) = 0.0
             WHERE(THM /= UNDEF) TMP=COS(THM)
             RLA_OASIS_SND(:,1) = TMP(1:NSEAL)
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
@@ -187,7 +187,7 @@
          ! dir : oceanographic convention (GRIDDED files) - 0 degree from north, 90 from east 
          ! theta : trigonometric convention ( 0 at East, 90 at North)
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_SDIR') THEN
-            TMP(1:NSEAL) = 0.0
+            TMP(1:NSEALM) = 0.0
             WHERE(THM /= UNDEF) TMP=SIN(THM)
             RLA_OASIS_SND(:,1) = TMP(1:NSEAL)
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
@@ -203,8 +203,8 @@
          ! Wave-ocean momentum flux (tauox in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TWOX') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(TAUOX /= UNDEF) TMP(:)=TAUOX(:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(TAUOX /= UNDEF) TMP=TAUOX
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -212,8 +212,8 @@
          ! Wave-ocean momentum flux (tauoy in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TWOY') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(TAUOY /= UNDEF) TMP(:)=TAUOY (:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(TAUOY /= UNDEF) TMP=TAUOY
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -221,8 +221,8 @@
          ! Wave-to-ocean TKE flux (phioc in W.m-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3__FOC') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(PHIOC /= UNDEF) TMP(:)=PHIOC(:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(PHIOC /= UNDEF) TMP=PHIOC
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -230,8 +230,8 @@
          ! Momentum flux due to bottom friction (taubblx in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TBBX') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(TAUOX /= UNDEF) TMP(:)=TAUBBL(:,1)
+            TMP(1:NSEALM) = 0.0
+            WHERE(TAUBBL(:,1) /= UNDEF) TMP(:)=TAUBBL(:,1)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -239,8 +239,8 @@
          ! Momentum flux due to bottom friction (taubbly in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TBBY') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(TAUOY /= UNDEF) TMP(:)=TAUBBL(:,2)
+            TMP(1:NSEALM) = 0.0
+            WHERE(TAUBBL(:,2) /= UNDEF) TMP(:)=TAUBBL(:,2)
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -248,8 +248,8 @@
          ! Energy flux due to bottom friction (phibbl in W.m-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3__FBB') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(PHIOC /= UNDEF) TMP(:)=PHIBBL(:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(PHIBBL /= UNDEF) TMP=PHIBBL
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -264,8 +264,8 @@
          ! x component of the near-bottom rms wave velocity (in m.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_UBRX') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(UBA(:) /= UNDEF) TMP=UBA(:)*COS(UBD(:))
+            TMP(1:NSEALM) = 0.0
+            WHERE(UBA /= UNDEF) TMP=UBA*COS(UBD)
             RLA_OASIS_SND(:,1) = TMP(1:NSEAL)
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -273,8 +273,8 @@
          ! y component of the near-bottom rms wave velocity (in m.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_UBRY') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(UBA(:) /= UNDEF) TMP=UBA(:)*SIN(UBD(:))
+            TMP(1:NSEALM) = 0.0
+            WHERE(UBA /= UNDEF) TMP=UBA*SIN(UBD)
             RLA_OASIS_SND(:,1) = TMP(1:NSEAL)
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -282,8 +282,8 @@
          ! Net wave-supported stress, u component (tauwix in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TAWX') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(TAUWIX /= UNDEF) TMP(:)=TAUWIX(:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(TAUWIX /= UNDEF) TMP=TAUWIX
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -291,8 +291,8 @@
          ! Net wave-supported stress, v component (tauwix in m2.s-2)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TAWY') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(TAUWIY /= UNDEF) TMP(:)=TAUWIY(:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(TAUWIY /= UNDEF) TMP=TAUWIY
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -300,8 +300,8 @@
          ! Volume transport associated to Stokes drift, u component (tusx in m2.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TUSX') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(TUSX /= UNDEF) TMP(:)=TUSX(:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(TUSX /= UNDEF) TMP=TUSX
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -309,8 +309,8 @@
          ! Volume transport associated to Stokes drift, v component (tusy in m2.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_TUSY') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(TUSY /= UNDEF) TMP(:)=TUSY(:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(TUSY /= UNDEF) TMP=TUSY
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -318,8 +318,8 @@
          ! Surface Stokes drift, u component (ussx in m.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_USSX') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(USSX /= UNDEF) TMP(:)=USSX(:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(USSX /= UNDEF) TMP=USSX
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -327,8 +327,8 @@
          ! Surface Stokes drift, v component (ussy in m.s-1)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3_USSY') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(USSY /= UNDEF) TMP(:)=USSY(:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(USSY /= UNDEF) TMP=USSY
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF
@@ -336,8 +336,8 @@
          ! Mean wave length (wlm in m)
          ! ---------------------------------------------------------------------
          IF (SND_FLD(IB_DO)%CL_FIELD_NAME == 'WW3___LM') THEN
-            TMP(1:NSEAL) = 0.0
-            WHERE(WLM /= UNDEF) TMP(:)=WLM(:)
+            TMP(1:NSEALM) = 0.0
+            WHERE(WLM /= UNDEF) TMP=WLM
             RLA_OASIS_SND(:,1) = DBLE(TMP(1:NSEAL))
             CALL CPL_OASIS_SND(IB_DO, ID_OASIS_TIME, RLA_OASIS_SND, LL_ACTION)
          ENDIF

--- a/regtests/bin/matrix.comp
+++ b/regtests/bin/matrix.comp
@@ -279,6 +279,9 @@
                             ncdump $file > $output/${basename}_base.txt
                             ncdump $return_comp/$run/$file > $output/${basename}_comp.txt
                             diff $output/${basename}_base.txt $output/${basename}_comp.txt > $output/${basename}_diff.txt
+                            if [[ $basename == rmp_* ]]; then
+                              grep -v "history" $output/${basename}_diff.txt > $output/${basename}_diff.txt
+                            fi
                             size_1=`wc -l $output/${basename}_diff.txt | awk '{ print $1}'` 
                             if [ "$size_1" = '0' ]
                             then


### PR DESCRIPTION
Bug fix in where sentences present in coupling routines, which generate out of bounds runtime errors. These changes have been tested offline and the runtime errors disappear. The coupling regtests are different from the reference, which indicates that this bug generates errors in the results of coupled configurations. This is supported by the fact that the OASICM regtest, which is not influenced by this bug, passes without problems.

I do not copy the results of the regtests because they are quite large. It would be convenient to merge these changes to the staging_oc20 branch before implementing further development.