### PR TITLE
WW3_PRNC Interp bug

### DIFF
--- a/model/ftn/ww3_prnc.ftn
+++ b/model/ftn/ww3_prnc.ftn
@@ -1698,7 +1698,7 @@
               END IF
             END IF
             CALL CHECK_ERR(IRET)
-            ! forces to 0 values that are undefined
+            ! forces undefined values to FILLVALUE
             WHERE(XC.NE.XC) XC = FILLVALUE
             WHERE (XC.NE.FILLVALUE) XC=XC*XCFAC+XCOFF
 
@@ -1871,8 +1871,11 @@
                 CALL INTERP(MXM, MYM, YC, IX21, IX22, IY21, IY22,      &
                                RD11, RD12, RD21, RD22, FILLVALUE, FY)
 
-                CALL INTERP(MXM, MYM, AC, IX21, IX22, IY21, IY22,      &
-                               RD11, RD12, RD21, RD22, FILLVALUE, FA)
+                IF(FLSTAB) THEN
+                  ! AC only populated if FLSTAB is true
+                  CALL INTERP(MXM, MYM, AC, IX21, IX22, IY21, IY22,    &
+                                 RD11, RD12, RD21, RD22, FILLVALUE, FA)
+                ENDIF
 
                 CALL INTERP(MXM, MYM, SQRT(XC**2+YC**2), IX21, IX22,   &
                                IY21, IY22, RD11, RD12, RD21, RD22,     &
@@ -2406,11 +2409,21 @@
           IF(FACTOR.GT.0.0) THEN
             FA(IX,IY) = FA(IX,IY) / FACTOR
           ELSE
-            IF(XC(IX,IY).EQ.FILLVALUE) THEN
-              FA(IX,IY) = 0.0
+            ! Interpolation coefficients sum to zero - could be on a boundary
+            ! (see note in "method" above). If any surrounding points have a
+            ! valid value then use one of them, otherwise set to zero.
+            IF( XC(IX21(IX,IY),IY21(IX,IY)) .NE. FILLVALUE) THEN
+              FA(IX,IY) = XC(IX21(IX,IY),IY21(IX,IY))
+            ELSE IF( XC(IX22(IX,IY),IY21(IX,IY)) .NE. FILLVALUE) THEN
+              FA(IX,IY) = XC(IX22(IX,IY),IY21(IX,IY))
+            ELSE IF( XC(IX21(IX,IY),IY22(IX,IY)) .NE. FILLVALUE) THEN
+              FA(IX,IY) = XC(IX21(IX,IY),IY22(IX,IY))
+            ELSE IF( XC(IX22(IX,IY),IY22(IX,IY)) .NE. FILLVALUE) THEN
+              FA(IX,IY) = XC(IX22(IX,IY),IY22(IX,IY))
             ELSE
-              FA(IX,IY) = XC(IX,IY)
-            ENDIF
+              ! All surrounding points are FILLVALUE - set to zero.
+              FA(IX,IY) = 0.0
+            END IF
           END IF
         END DO
       END DO


### PR DESCRIPTION
# Pull Request Summary
Bug fix for out-of-bounds error in ww3_prnc interp routine.

## Description
In certain circumstances, the `XC` array (input field) in the INTERP routine was being accessed with the wrong indices causing an out-of-bounds array access.

This was happening in `ww3_tp2.15` when the `AC` array was being interpolated (which is full of zeros as the `FLSTAB` flag is not set). In this case, some points have 0.0 set for all interpolation weights, but the value in array `AC` is non-zero. Under this condition, an array access was being made on array `AC` (`XC` in the interp routine) with incorrect indices. 

The fix is to check each surrounding point for a valid value (using the correct IXxx and IYxx indices), and set to zero all surrouning points are indeed FILLVALUE. This check is necessary to accound for "boundary" points when coupling with an ocean model.

I have also added an extra conditional to only interpolate the `AC` array if the `FLSTAB` flag is set; inspection of the code shows that the AC array is always zero unless `FLSTAB = .True.`

### Issue(s) addressed
- fixes #NOAA-EMC/WW3#420

### Testing
* How were these changes tested? Run of regression tests that use ww3_prnc program.
* Are the changes covered by regression tests? Yes
* If a new feature was added, was a new regression test added? N/A
* Have regression tests been run? Yes
* Which compiler / HPC you used to run the regression tests in the PR?  Cray HPC, GNU fortran.


### Regression test results
Tests run only for only regression tests that use the `ww3_prnc` program.
Differences only in ww3_tp2.15, as expected (affects wind.ww3, which in turn has small knock on effects to model outputs)

```
**********************************************************************
********************* non-identical cases ****************************
**********************************************************************
ww3_tp2.15/./work_PR3_UQ_RHO                     (7 files differ)
ww3_tp2.15/./work_PR3_UQ_RHO_MPI                     (5 files differ)
ww3_tp2.15/./work_PR3_UQ                     (6 files differ)
ww3_tp2.15/./work_MPI_5km                     (3 files differ)
ww3_tp2.15/./work_5km                     (5 files differ)
ww3_tp2.15/./work_PR3_UQ_MPI                     (39 files differ)

**********************************************************************
************************ identical cases *****************************
**********************************************************************
ww3_tic1.4/./work_IC2IS2_IC2b
ww3_tic1.4/./work_IC0IS2_1000
ww3_tic1.4/./work_IC1IS2_1000
ww3_tic1.4/./work_IC2IS2_IC2d
ww3_tp2.17/./work_mc
ww3_tp2.17/./work_ma
ww3_tp2.17/./work_mb
ww3_tp2.17/./work_c
ww3_tp2.17/./work_b
ww3_tp2.17/./work_a
ww3_tp2.18/./work_TIDE
ww3_tp2.18/./work_TIDE_MPI
ww3_tp2.8/./work_PR3_UQ

```
