### PR TITLE
:bug: POLAT not being correctly read in ww3_ounf

### DIFF
--- a/model/ftn/w3ounfmetamd.ftn
+++ b/model/ftn/w3ounfmetamd.ftn
@@ -296,10 +296,12 @@
 
       ! 2. Set direction convention:
       DIRCOM = ""
-!/RTD      IF ( FLAGUNR ) THEN
-!/RTD        DIRCOM = 'True North'
-!/RTD      ELSE IF ( .NOT. FLAGUNR ) THEN
-!/RTD        DIRCOM = 'Rotated Pole Grid North'
+!/RTD      IF( FLRTD ) THEN
+!/RTD        IF ( FLAGUNR ) THEN
+!/RTD          DIRCOM = 'True North'
+!/RTD        ELSE IF ( .NOT. FLAGUNR ) THEN
+!/RTD          DIRCOM = 'Rotated Pole Grid North'
+!/RTD        ENDIF
 !/RTD      ENDIF
 
       !  Set partitioning method comment and standard name templates:

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -255,10 +255,6 @@
 
 !/SMC      SMCGRD = .TRUE.
 !
-!/RTD ! Is the grid really rotated
-!/RTD      IF ( Polat < 90. ) RTDL = .True.
-!/RTD !
-!
       ! Default epoch time:
       TEPOCH(1) = 19900101
       TEPOCH(2) = 0
@@ -269,6 +265,10 @@
 !
       CALL W3IOGR ( 'READ', NDSM )
       WRITE (NDSO,920) GNAME
+!
+!/RTD ! Is the grid really rotated?
+!/RTD      IF ( Polat < 90. ) RTDL = .True.
+!/RTD !
 !
 !--- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 ! 3.  Read general data and first fields from file


### PR DESCRIPTION
# Pull Request Summary
Fixed incorrect placement of POLAT check.

## Description
In ww3_ounf a check is made when using RTD switch to see if the grid really is a formulated on a rotated pole (POLAT < 90)
However, this check was being made before the call to W3IOGR, so POLAR had not been loaded yet from the mod_def.ww3 file.

This resulted in output variables relating to rotated pole grids being added to the netCDF file even when the grid is formulated on a standard pole.

The fix is simple - move the check after the W3IOGR call.

### Issue(s) addressed
- fixes noaa-emc/ww3/issues/430

### Check list  
* Is your feature branch up to date with the authoritative repository (NOAA/develop)? yes
* Make sure you have checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop) and [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number)
* Reviewers: @aliabdolali 


### Testing
* How were these changes tested? Yes - on a UKMO model configuration.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* If a new feature was added, was a new regression test added? N/A
* Have regression tests been run? ww3_tr1 rotated pole regression tests.
* Which compiler / HPC you used to run the regression tests in the PR? GNU on Linux, CrayFortran on Cray HPC
* Please provide the summary output of matrix.comp (_matrix.Diff.txt_, _matrixCompFull.txt_ and _matrixCompSummary.txt_):    
Please indicate the expected changes in the outputs ([excluding the known list of non-identical tests](https://github.com/NOAA-EMC/WW3/wiki/How-to-use-matrix.comp-to-compare-regtests-with-master#4-look-at-results)).


