### PR TITLE
New coordinates attribute in ww3_ounf

### DIFF
--- a/model/ftn/w3ounfmetamd.ftn
+++ b/model/ftn/w3ounfmetamd.ftn
@@ -6,7 +6,7 @@
 !/                  |           C. Bunney               |
 !/                  |                                   |
 !/                  |                        FORTRAN 90 |
-!/                  | Last update :         22-Mar-2021 |
+!/                  | Last update :         02-Sep-2021 |
 !/                  +-----------------------------------+
 !/
 !/    02-Nov-2020 : Creation                            ( version 7.12 )
@@ -18,6 +18,7 @@
 !/    02-Feb-2021 : Improved partitioned parameter      ( version 7.12 )
 !/                  template string implementation.
 !/    22-Mar-2021 : Adds extra coupling fields          ( version 7.xx )
+!/    02-Sep-2021 : Add coordinates attribute           ( version 7.12 )
 !/
 !  1. Purpose :
 !
@@ -222,6 +223,9 @@
       CHARACTER(LEN=128) :: CRS_NAME = ''
       TYPE(META_LIST_T)  :: CRS_META
       LOGICAL            :: CRS_IS_DEFAULT = .FALSE. ! True if CRS set by this module
+
+      ! "coordinates" attribute - for defining auxiliary coordinates (for all variables)
+      CHARACTER(LEN=256) :: COORDS_ATTR = ''
 
       ! Type for storing partitioned parameter template strings.
       ! Defined as a linked-list
@@ -1935,6 +1939,11 @@
 
       IF(CRS_NAME .NE. '' .AND. CRS_NAME .NE. UNSETC) THEN
         ERR = NF90_PUT_ATT(NCID, VARID, 'grid_mapping', CRS_NAME)
+        IF(ERR /= NF90_NOERR) RETURN
+      ENDIF
+
+      IF(COORDS_ATTR .NE. '' .AND. COORDS_ATTR .NE. UNSETC) THEN
+        ERR = NF90_PUT_ATT(NCID, VARID, 'coordinates', ADJUSTL(COORDS_ATTR))
         IF(ERR /= NF90_NOERR) RETURN
       ENDIF
 

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -8,7 +8,7 @@
 !/                  |           F. Ardhuin              |
 !/                  |           M. Accensi              |
 !/                  |                        FORTRAN 90 |
-!/                  | Last update :         22-Mar-2021 |
+!/                  | Last update :         02-Sep-2021 |
 !/                  +-----------------------------------+
 !/
 !/    17-Mar-2010 : Creation                            ( version 3.14_SHOM )
@@ -47,6 +47,7 @@
 !/                  and alternative dir/mag output.
 !/    02-Feb-2021 : Make default global meta optional   ( version 7.12 )
 !/    22-Mar-2021 : New coupling fields output          ( version 7.xx )
+!/    02-Sep-2021 : Added coordinates attribute         ( version 7.12 )
 !/
 !/    Copyright 2009-2013 National Weather Service (NWS),
 !/       National Oceanic and Atmospheric Administration.  All rights
@@ -180,7 +181,7 @@
                               WRITE_META, WRITE_GLOBAL_META,           &
                               WRITE_FREEFORM_META_LIST,                &
                               META_T, NCVARTYPE, CRS_META, CRS_NAME,   &
-                              FL_DEFAULT_GBL_META
+                              FL_DEFAULT_GBL_META, COORDS_ATTR
 !
       USE NETCDF
 
@@ -3351,6 +3352,10 @@
 !/SMC              IRET = NF90_DEF_VAR(NCID, 'latitude', NF90_FLOAT, DIMID(2), VARID(2))
 !/SMC              CALL CHECK_ERR(IRET)
 !/SMC
+!/SMC              ! Latitude and longitude are auxililary variables in type 1 sepoint
+!/SMC              ! SMC file; add to "coordinates" attribute:
+!/SMC              COORDS_ATTR = TRIM(COORDS_ATTR) // " latitude longitude"
+!/SMC
 !/SMC              ! For seapoint style SMC grid, also define out cell size variables:
 !/SMC              IRET = NF90_DEF_VAR(NCID, 'cx', NF90_SHORT, DIMID(2), VARID(5))
 !/SMC              CALL CHECK_ERR(IRET)
@@ -3586,6 +3591,8 @@
          IRET = NF90_PUT_ATT(NCID, VARID(12), 'calendar', 'gregorian')
          CALL CHECK_ERR(IRET)
 
+         ! Add these to auxiliary coordinates list:
+         COORDS_ATTR = TRIM(COORDS_ATTR) // " forecast_period forecast_reference_time"
       ENDIF
 !
 ! triangles for irregular grids

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -3354,7 +3354,7 @@
 !/SMC              IRET = NF90_DEF_VAR(NCID, 'latitude', NF90_FLOAT, DIMID(2), VARID(2))
 !/SMC              CALL CHECK_ERR(IRET)
 !/SMC
-!/SMC              ! Latitude and longitude are auxililary variables in type 1 sepoint
+!/SMC              ! Latitude and longitude are auxililary variables in type 1 sea point
 !/SMC              ! SMC file; add to "coordinates" attribute:
 !/SMC              COORDS_ATTR = TRIM(COORDS_ATTR) // " latitude longitude"
 !/SMC

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -3278,6 +3278,8 @@
       INTEGER                           :: DEFLATE=1
 !
       CHARACTER                         :: ATTNAME*120,ATTVAL*120
+!
+      COORDS_ATTR = ''
 !      
 ! Creation in netCDF3 or netCDF4
 !


### PR DESCRIPTION
# Pull Request Summary
Adds new "coordinates" attribute  to output fields in ww3_ounf. This allows auxiliary time coordinates such as 'forecast_period'  'forecast_reference_time' to be correctly associated with a variable. The same applies to the auxiliary 'latitude' and 'longitude' variables to when outputting an SMC seapoint only file.

## Description
Adds a new "coordinates" attribute to all output variables containing a list of auxiliary coordinate variables (if required).

If "forecast variables" are enabled (`FCVARS = .True.`) then the "forecast_period" and "forecast_reference_time" will be added to the coodinate list.

If a type 1 SMC grid is output (1D seapoint dimension), then the "latitude" and "longitude" variables will be added to the coordinate list.

### Issue(s) addressed

### Check list  
* Is your feature branch up to date with the authoritative repository (NOAA/develop)? yes
* Make sure you have checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop) and [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) Done
 
* Reviewers: @mickaelaccensi 

### Commit Message
* [ww3_ounf] Adds new "coordinate" attribute to output variables, where appropriate.

### Testing
* How were these changes tested? Regtests, Local Met Office tests.
* Are the changes covered by regression tests? (If not, why? Do new tests need to be added?) Yes
* If a new feature was added, was a new regression test added? No
* Have regression tests been run? Yes
* Which compiler / HPC you used to run the regression tests in the PR? Cray HPC, GNU Fortran
* Please provide the summary output of matrix.comp:

[matrixComp_fb_ounfcoords.zip](https://github.com/ukmo-waves/WW3/files/7127714/matrixComp_fb_ounfcoords.zip)

### Summary of differences:

**Expected differences:**
ww3_tnc1, ww3_tp2.10 - New coordinate attribute.

**Known non b4b tests:**
mww3_test_03/./work_PR2_UQ_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2                     (10 files differ)
mww3_test_03/./work_PR3_UQ_MPI_d2_c                     (11 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2                     (8 files differ)
mww3_test_03/./work_PR1_MPI_e                     (1 files differ)
mww3_test_03/./work_PR1_MPI_d2                     (11 files differ)
mww3_test_03/./work_PR2_UNO_MPI_d2                     (9 files differ)
mww3_test_03/./work_PR3_UNO_MPI_d2_c                     (12 files differ)
mww3_test_03/./work_PR2_UQ_MPI_d2                     (12 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e                     (1 files differ)
mww3_test_03/./work_PR3_UNO_MPI_e_c                     (1 files differ)

ww3_tp2.17: Known issue with Grib compilation.



