### PR TITLE
driving data frequency hotfix to UKMO_PS45 branch

### DIFF
--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -1961,6 +1961,7 @@
             ELSE
               DTTST  = DSEC21 ( TIME0 , TTT )
             END IF
+!/OASIS          ELSE
 !/OASIS            IF ( DTOUT(7).NE.0 ) THEN
 !/OASIS              ! TFN not initialized at TIME=TIME00, using TIME instead
 !/OASIS              IF(NINT(DSEC21(TIME00,TIME)) == 0) THEN

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -1961,11 +1961,17 @@
             ELSE
               DTTST  = DSEC21 ( TIME0 , TTT )
             END IF
-!/OASIS          ELSE 
-!/OASIS            ID_OASIS_TIME = NINT(DSEC21 ( TIME00 , TIME ))
-!/OASIS            IF ( (DTOUT(7).NE.0) .AND.                               &
-!/OASIS                 (MOD(ID_OASIS_TIME, NINT(DTOUT(7))) .EQ. 0 ) .AND. &
-!/OASIS                 (DSEC21 (TIME, TIMEEND) .GT. 0.0)) DTTST=0.
+!/OASIS            IF ( DTOUT(7).NE.0 ) THEN
+!/OASIS              ! TFN not initialized at TIME=TIME00, using TIME instead
+!/OASIS              IF(NINT(DSEC21(TIME00,TIME)) == 0) THEN
+!/OASIS                ID_OASIS_TIME = 0
+!/OASIS                DTTST=0.
+!/OASIS              ELSE
+!/OASIS                ID_OASIS_TIME = NINT(DSEC21 ( TIME00 , TFN(:,J) ))
+!/OASIS                IF ( NINT(MOD(DSEC21(TIME00,TIME), DTOUT(7))) .EQ. 0 .AND. &
+!/OASIS                     DSEC21 (TFN(:,J), TIMEEND) .GT. 0.0 ) DTTST=0.
+!/OASIS              ENDIF
+!/OASIS            ENDIF
           END IF
 !
 !/T          WRITE (NDST,9071) IDSTR(J), DTTST


### PR DESCRIPTION
Bugfix to allow coupling time steps to happen at times different to the update of driving data.

This is a backport of the bugfix made to `develop` here https://github.com/NOAA-EMC/WW3/pull/652
This bugfix will be applied as a hotfix to the `ukmo_ps45-1.hotfixes branch`

After merging, this commit will be tagged as `ukmo_ps45-1.hotfix2`
