### PR TITLE
Backport ukmo ps45 bugfixes

### DIFF
--- a/model/ftn/w3wavemd.ftn
+++ b/model/ftn/w3wavemd.ftn
@@ -705,9 +705,9 @@
 ! 1.g Air density time
 !
       IF ( FLRHOA ) THEN
-          DTTST1 = DSEC21 ( TU0 , TUN )
-          DTTST2 = DSEC21 ( TU0 , TIME )
-          DTTST3 = DSEC21 ( TEND , TUN )
+          DTTST1 = DSEC21 ( TR0 , TUN )
+          DTTST2 = DSEC21 ( TR0 , TIME )
+          DTTST3 = DSEC21 ( TEND , TRN )
 !/T          WRITE (NDST,9018) DTTST1, DTTST2, DTTST3
           IF ( DTTST1.LT.0. .OR. DTTST2.LT.0. .OR. DTTST3.LT.0. ) THEN
               IF ( IAPROC .EQ. NAPERR ) WRITE (NDSE,1008)

--- a/model/ftn/w3wavemd.ftn
+++ b/model/ftn/w3wavemd.ftn
@@ -705,7 +705,7 @@
 ! 1.g Air density time
 !
       IF ( FLRHOA ) THEN
-          DTTST1 = DSEC21 ( TR0 , TUN )
+          DTTST1 = DSEC21 ( TR0 , TRN )
           DTTST2 = DSEC21 ( TR0 , TIME )
           DTTST3 = DSEC21 ( TEND , TRN )
 !/T          WRITE (NDST,9018) DTTST1, DTTST2, DTTST3

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -346,6 +346,7 @@
 !/MPI      LOGICAL             :: FLHYBR = .FALSE.
 !/OMPH      INTEGER             :: THRLEV
 !/OASIS      LOGICAL             :: L_MASTER    
+!/OASIS      LOGICAL             :: FIRST_STEP = .TRUE.
 !
 !/
 !/ ------------------------------------------------------------------- /
@@ -1997,12 +1998,17 @@
 !/OASIS                COUPL_COMM = MPI_COMM
 !/OASICM                IF (FLAGSC(J)) FLAGSCI = .TRUE.
 !/OASICM                IF (.NOT.FLAGSCI) ID_OASIS_TIME = -1
+!/OASIS                IF (ID_OASIS_TIME >0 .OR. FIRST_STEP .OR.       &
+!/OASIS                                     .NOT. FLAGSC(J)) THEN
                 CALL W3FLDG ('READ', IDSTR(J), NDSF(J),         &
                              NDST, NDSEN, NX, NY, NX, NY, TIME0, TIMEN, &
                              TTT, XXX, XXX, XXX, TI1, XXX, XXX, ICEP1,  &
                              IERR, FLAGSC(J)                            &
 !/OASICM                             , COUPL_COMM                       &
                              )
+!/OASIS                ELSE
+!/OASIS                  IERR = -1
+!/OASIS                END IF
               END IF
               IF ( IERR .LT. 0 ) FLLST_ALL(J) = .TRUE.
 
@@ -2058,12 +2064,17 @@
 !/OASIS                COUPL_COMM = MPI_COMM
 !/OASICM                IF (FLAGSC(J)) FLAGSCI = .TRUE.
 !/OASICM                IF (.NOT.FLAGSCI) ID_OASIS_TIME = -1
+!/OASIS                IF (ID_OASIS_TIME >0 .OR. FIRST_STEP .OR.       &
+!/OASIS                                     .NOT. FLAGSC(J)) THEN
                 CALL W3FLDG ('READ', IDSTR(J), NDSF(J),         &
                              NDST, NDSEN, NX, NY, NX, NY, TIME0, TIMEN, &
                              TTT, XXX, XXX, XXX, TI5, XXX, XXX, ICEP5,  &
                              IERR, FLAGSC(J)                            &
 !/OASICM                             , COUPL_COMM                       &
                              )
+!/OASIS                ELSE
+!/OASIS                  IERR = -1
+!/OASIS                END IF
               END IF
               IF ( IERR .LT. 0 )FLLST_ALL(J) = .TRUE.
 
@@ -2126,12 +2137,17 @@
 !/TIDE                ELSE
 !/OASIS                COUPL_COMM = MPI_COMM
 !/OASOCM                IF (.NOT.FLAGSC(J)) ID_OASIS_TIME = -1
+!/OASIS                IF (ID_OASIS_TIME >0 .OR. FIRST_STEP .OR.       &
+!/OASIS                                     .NOT. FLAGSC(J)) THEN
                 CALL W3FLDG ('READ', IDSTR(J), NDSF(J),         &
                              NDST, NDSEN, NX, NY, NX, NY, TIME0, TIMEN, &
                              TTT, XXX, XXX, XXX, TLN, XXX, XXX, WLEV,   &
                              IERR, FLAGSC(J)                            &
 !/OASOCM                             , COUPL_COMM                       &
                              )
+!/OASIS                ELSE
+!/OASIS                  IERR = -1
+!/OASIS                END IF
 !/TIDE                END IF
               END IF
               IF ( IERR .LT. 0 ) FLLSTL = .TRUE.
@@ -2162,12 +2178,15 @@
 !/TIDE                ELSE
 !/OASIS                COUPL_COMM = MPI_COMM
 !/OASOCM                IF (.NOT.FLAGSC(J)) ID_OASIS_TIME = -1
+!/OASIS                IF (ID_OASIS_TIME >0 .OR. FIRST_STEP .OR.       &
+!/OASIS                                     .NOT. FLAGSC(J)) THEN
                 CALL W3FLDG ('READ', IDSTR(J), NDSF(J),         &
                              NDST, NDSEN, NX, NY, NX, NY, TIME0, TIMEN, &
                              TC0, CX0, CY0, XXX, TCN, CXN, CYN, XXX,    &
                              IERR, FLAGSC(J)                            &
 !/OASOCM                             , COUPL_COMM                       &
                              )
+!/OASIS                END IF
 !/TIDE                END IF
               END IF
 
@@ -2188,12 +2207,15 @@
               ELSE
 !/OASIS                COUPL_COMM = MPI_COMM
 !/OASACM                IF (.NOT.FLAGSC(J)) ID_OASIS_TIME = -1
+!/OASIS                IF (ID_OASIS_TIME >0 .OR. FIRST_STEP .OR.       &
+!/OASIS                                     .NOT. FLAGSC(J)) THEN
                 CALL W3FLDG ('READ', IDSTR(J), NDSF(J),         &
                              NDST, NDSEN, NX, NY, NX, NY, TIME0, TIMEN, &
                              TW0, WX0, WY0, DT0, TWN, WXN, WYN, DTN,    &
                              IERR, FLAGSC(J)                            &
 !/OASACM                             , COUPL_COMM                       &
                              )
+!/OASIS                END IF
               END IF
 
 ! ICE : ice conc.
@@ -2206,12 +2228,17 @@
 !/OASIS                COUPL_COMM = MPI_COMM
 !/OASICM                IF (FLAGSC(J)) FLAGSCI = .TRUE.
 !/OASICM                IF (.NOT.FLAGSCI) ID_OASIS_TIME = -1
+!/OASIS                IF (ID_OASIS_TIME >0 .OR. FIRST_STEP .OR.       &
+!/OASIS                                     .NOT. FLAGSC(J)) THEN
                 CALL W3FLDG ('READ', IDSTR(J), NDSF(J),            &
                              NDST, NDSEN, NX, NY, NX, NY, TIME0, TIMEN,    &
                              TTT, XXX, XXX, XXX, TIN, XXX, BERGI, ICEI,    &
                              IERR, FLAGSC(J)                               &
 !/OASICM                             , COUPL_COMM                          &
                             )
+!/OASIS                ELSE
+!/OASIS                  IERR = -1
+!/OASIS                END IF
                 IF ( IERR .LT. 0 ) FLLSTI = .TRUE.
 !could be:      IF ( IERR .LT. 0 ) FLLST_ALL(J) = .TRUE.
               END IF
@@ -2233,12 +2260,15 @@
               ELSE
 !/OASIS                COUPL_COMM = MPI_COMM
 !/OASACM                IF (.NOT.FLAGSC(J)) ID_OASIS_TIME = -1
+!/OASIS                IF (ID_OASIS_TIME >0 .OR. FIRST_STEP .OR.       &
+!/OASIS                                     .NOT. FLAGSC(J)) THEN
                 CALL W3FLDG ('READ', IDSTR(J), NDSF(J),         &
                              NDST, NDSEN, NX, NY, NX, NY, TIME0, TIMEN, &
                              TU0, UX0, UY0, XXX, TUN, UXN, UYN, XXX,    &
                              IERR, FLAGSC(J)                            &
 !/OASACM                             , COUPL_COMM                               &
                              )
+!/OASIS                END IF
               END IF
 
 ! RHO : air density
@@ -2257,12 +2287,15 @@
               ELSE
 !/OASIS                COUPL_COMM = MPI_COMM
 !/OASACM                IF (.NOT.FLAGSC(J)) ID_OASIS_TIME = -1
+!/OASIS                IF (ID_OASIS_TIME >0 .OR. FIRST_STEP .OR.       &
+!/OASIS                                     .NOT. FLAGSC(J)) THEN
                 CALL W3FLDG ('READ', IDSTR(J), NDSF(J),         &
                              NDST, NDSEN, NX, NY, NX, NY, TIME0, TIMEN, &
                              TR0, XXX, XXX, RH0, TRN, XXX, XXX, RHN,    &
                              IERR, FLAGSC(J)                            &
 !/OASACM                              , COUPL_COMM                               &
                              )
+!/OASIS                END IF
                 IF ( IERR .LT. 0 ) FLLSTR = .TRUE.
               END IF
 
@@ -2359,6 +2392,7 @@
 !
 ! update the next assimilation data time
 !
+!/OASIS      FIRST_STEP = .FALSE.
 
 !/MEMCHECK      write(740+IAPROC,*) 'memcheck_____:', 'WW3_SHEL SECTION 8'
 !/MEMCHECK      call getMallocInfo(mallinfos)


### PR DESCRIPTION
# Pull Request Summary
Backport two bugfixes from the official develop branch to the UKMO PS45 operational branch.
Comprises fixes for:
  - NOAA-EMC/WW3/pull/858 (changes to ww3_shel.ftn)
  - NOAA-EMC/WW3/pull/812 (changes to w3wavemd.ftn)

@ukmo-juan-castillo  can you please review and test this branch against your configs to make sure it is working correctly (the merge was not trivial due to the change from WW3 switches to `#ifdef` directives).

If all is well, I will merge it with the PS45-1.hotfixes  branch.

