### PR TITLE
Backport of duplicate oasis calls bugfix.

### DIFF
--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -1905,6 +1905,7 @@
 !/OASACM       CALL SND_FIELDS_TO_ATMOS()
 !/OASOCM       CALL SND_FIELDS_TO_OCEAN()
 !/OASICM       CALL SND_FIELDS_TO_ICE()
+!/OASIS       ID_OASIS_TIME = -1
 !/OASIS      END IF
 
   700 CONTINUE
@@ -1965,8 +1966,10 @@
 !/OASIS            IF ( DTOUT(7).NE.0 ) THEN
 !/OASIS              ! TFN not initialized at TIME=TIME00, using TIME instead
 !/OASIS              IF(NINT(DSEC21(TIME00,TIME)) == 0) THEN
-!/OASIS                ID_OASIS_TIME = 0
-!/OASIS                DTTST=0.
+!/OASIS                IF(ID_OASIS_TIME .LT. 0 .OR. .NOT. CPLT0) THEN
+!/OASIS                  ID_OASIS_TIME = 0
+!/OASIS                  DTTST=0.
+!/OASIS                ENDIF
 !/OASIS              ELSE
 !/OASIS                ID_OASIS_TIME = NINT(DSEC21 ( TIME00 , TFN(:,J) ))
 !/OASIS                IF ( NINT(MOD(DSEC21(TIME00,TIME), DTOUT(7))) .EQ. 0 .AND. &

--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -346,7 +346,6 @@
 !/MPI      LOGICAL             :: FLHYBR = .FALSE.
 !/OMPH      INTEGER             :: THRLEV
 !/OASIS      LOGICAL             :: L_MASTER    
-!/OASIS      LOGICAL             :: FIRST_STEP = .TRUE.
 !
 !/
 !/ ------------------------------------------------------------------- /
@@ -2363,7 +2362,6 @@
 !
 ! update the next assimilation data time
 !
-!/OASIS      FIRST_STEP = .FALSE.
 
 !/MEMCHECK      write(740+IAPROC,*) 'memcheck_____:', 'WW3_SHEL SECTION 8'
 !/MEMCHECK      call getMallocInfo(mallinfos)


### PR DESCRIPTION
# Pull Request Summary
Backport of bugfix for duplicate OASIS calls.

## Description
See https://github.com/NOAA-EMC/WW3/pull/1048
(Note - was never merged into HEAD of `develop` as was found recent code changes meant this is not an issue in develop)

### Testing
Needs testing by @ukmo-juan-castillo in a coupled build.