### PR TITLE
Revert previous duplicate OASIS call bugfix

### DIFF
--- a/model/ftn/ww3_shel.ftn
+++ b/model/ftn/ww3_shel.ftn
@@ -1905,7 +1905,6 @@
 !/OASACM       CALL SND_FIELDS_TO_ATMOS()
 !/OASOCM       CALL SND_FIELDS_TO_OCEAN()
 !/OASICM       CALL SND_FIELDS_TO_ICE()
-!/OASIS       ID_OASIS_TIME = -1
 !/OASIS      END IF
 
   700 CONTINUE
@@ -1966,10 +1965,8 @@
 !/OASIS            IF ( DTOUT(7).NE.0 ) THEN
 !/OASIS              ! TFN not initialized at TIME=TIME00, using TIME instead
 !/OASIS              IF(NINT(DSEC21(TIME00,TIME)) == 0) THEN
-!/OASIS                IF(ID_OASIS_TIME .LT. 0 .OR. .NOT. CPLT0) THEN
-!/OASIS                  ID_OASIS_TIME = 0
-!/OASIS                  DTTST=0.
-!/OASIS                ENDIF
+!/OASIS                ID_OASIS_TIME = 0
+!/OASIS                DTTST=0.
 !/OASIS              ELSE
 !/OASIS                ID_OASIS_TIME = NINT(DSEC21 ( TIME00 , TFN(:,J) ))
 !/OASIS                IF ( MOD(NINT(DSEC21(TIME00,TIME)), NINT(DTOUT(7))) .EQ. 0 .AND. &


### PR DESCRIPTION
# Pull Request Summary
Revert changes make in https://github.com/ukmo-waves/WW3/pull/44 to fix duplicate OASIS call.

## Description
No longer required as was a targeted fix for a particular configuration that was resolved via other later changes.

## Testing
@ukmo-juan-castillo can you confirm that this change is working ok for your coupled configuration?