### PR TITLE
Increase coordinate precision for regridded SMC grids

### DIFF
--- a/model/ftn/w3gridmd.ftn
+++ b/model/ftn/w3gridmd.ftn
@@ -591,10 +591,12 @@
 !
       REAL                    :: RXFR, RFR1, SIGMA, SXFR, FACHF,      &
                                  VSC, VSC0, VOF, DVSMC,               &
-                                 ZLIM, X, Y, XP,  XO0, YO0, DXO, DYO, &
+                                 ZLIM, X, Y, XP,                      &
                                  XO, YO, RD(4), RDTOT,                &
                                  FACTOR, RTH0, FMICHE, RWNDC,         &
                                  WCOR1, WCOR2
+
+      DOUBLE PRECISION        :: XO0, YO0, DXO, DYO
 !
       CHARACTER(LEN=4)        :: GSTRG, CSTRG
 !

--- a/model/ftn/w3gridmd.ftn
+++ b/model/ftn/w3gridmd.ftn
@@ -595,7 +595,6 @@
                                  XO, YO, RD(4), RDTOT,                &
                                  FACTOR, RTH0, FMICHE, RWNDC,         &
                                  WCOR1, WCOR2
-
       DOUBLE PRECISION        :: XO0, YO0, DXO, DYO
 !
       CHARACTER(LEN=4)        :: GSTRG, CSTRG

--- a/model/ftn/w3metamd.ftn
+++ b/model/ftn/w3metamd.ftn
@@ -25,7 +25,7 @@
       TYPE META_PAIR_T
         CHARACTER(LEN=64)  :: ATTNAME = UNSETC
         CHARACTER(LEN=120) :: ATTVAL = UNSETC
-        CHARACTER          :: TYPE = 'c'    ! c,i,f/r
+        CHARACTER          :: TYPE = 'c'    ! c,i,f/r,d
         TYPE(META_PAIR_T), POINTER  :: NEXT
       END TYPE META_PAIR_T
 
@@ -40,6 +40,7 @@
         MODULE PROCEDURE META_LIST_APPEND_R
         MODULE PROCEDURE META_LIST_APPEND_I
         MODULE PROCEDURE META_LIST_APPEND_C
+        MODULE PROCEDURE META_LIST_APPEND_D
       END INTERFACE META_LIST_APPEND
 
 
@@ -232,6 +233,34 @@
       END SUBROUTINE META_LIST_APPEND_C
 
 !     Append pair to list
+
+!/------------------------------------------------------------------ /
+!> @brief Append DOUBLE value attribute to list
+!>
+!> @param[in,out] LIST     The list to append to
+!> @param[in]     ATTNAME  The attribute name
+!> @param[in]     DVAL     The attribute value (DOUBLE)
+!>
+!> @author Kit Stokes
+!/------------------------------------------------------------------- /
+      SUBROUTINE META_LIST_APPEND_D(LIST, ATTNAME, DVAL)
+
+      IMPLICIT NONE
+
+      TYPE(META_LIST_T), INTENT(INOUT) :: LIST
+      CHARACTER(*), INTENT(IN)         :: ATTNAME
+      DOUBLE PRECISION, INTENT(IN)     :: DVAL
+!/------------------------------------------------------------------- /
+!/ Local parameters
+!/
+      TYPE(META_PAIR_T) :: META
+
+      META%ATTNAME = ATTNAME
+      WRITE(META%ATTVAL,*) DVAL
+      META%TYPE = 'd'
+      CALL META_LIST_APPEND(LIST, META)
+ 
+      END SUBROUTINE META_LIST_APPEND_D
 
 
 !/ ------------------------------------------------------------------- /

--- a/model/ftn/w3ounfmetamd.ftn
+++ b/model/ftn/w3ounfmetamd.ftn
@@ -66,8 +66,8 @@
 !     attribute. This extra attribute can take an optional "type"
 !     keyworkd to specify the variable tpye of the metadata. If
 !     no type is supplied, it defaults to a characer type. Valid
-!     types are one of ["c", "r", "i"] for character/string,
-!     real/float or integer values respectively.
+!     types are one of ["c", "r", "i", "d"] for character/string,
+!     real/float, integer, or double values respectively.
 !
 !     Global meta data can be specified with a special "META global" line:
 !
@@ -927,7 +927,7 @@
 !     or EOF is found. Splits meta pairs on the = character.
 !
 !     Note - the "extra" metadata pair can also provide a variable
-!     type ("c", "i", or "r"; for character, int or real respectively)
+!     type ("c", "i", "r", or "d"; for character, int, real, or double respectively)
 !
 !  3. Parameters :
 !
@@ -1092,9 +1092,9 @@
 !
 !     It is important to quote strings if they contain spaces.
 !
-!     Valid types are "c" "r/f", and "i" for character, real/float and
-!     integer values.
-
+!     Valid types are "c" "r/f", "i", and "d" for character, real/float,
+!     integer, and double values respectively.
+!
 !  3. Parameters :
 !
 !     Parameter list
@@ -1116,6 +1116,7 @@
 !
       REAL :: R
       INTEGER :: I, IERR
+      DOUBLE PRECISION :: D
 
       ! Get attribute and type (default to "c" if no type set)
       ATT_TYPE = 'c'
@@ -1140,6 +1141,13 @@
              CALL EXTCDE(10)
            ENDIF
 
+        CASE("d")
+           READ(attv, *, iostat=ierr) d
+           IF(ierr .ne. 0) THEN
+             WRITE(NDSE, 8001) "DOUBLE", TRIM(FN_META), ILINE, TRIM(ATTV)
+             CALL EXTCDE(10)
+           ENDIF
+
         CASE("c")
            ! Always ok.
 
@@ -1156,7 +1164,7 @@
                '  => ', A /)
 !
  8002 FORMAT (/' *** WAVEWATCH III ERROR IN W3OUNFMETA : '/           &
-               '     ATTRIBUTE TYPE SHOULD BE ONE OF [c,i,r] '/       &
+               '     ATTRIBUTE TYPE SHOULD BE ONE OF [c,i,r,d] '/       &
                '     FILENAME = ', A /                                &
                '     LINE NO =', I5 /                                 &
                '  => ', A /)
@@ -1188,7 +1196,7 @@
 !     or EOF is found. Splits meta pairs on the = character.
 !
 !     Freeform metadata pairs can also provide a variable type
-!     ("c", "i", or "r"; for character, int or real respectively).
+!     ("c", "i", "r", or "d"; for character, int, real, or double respectively).  
 !     String values with spaces should be quoted.
 !
 !  3. Parameters :
@@ -2035,6 +2043,7 @@
 !/
       INTEGER :: I, IVAL
       REAL    :: RVAL
+      DOUBLE PRECISION :: DVAL
       TYPE(META_PAIR_T), POINTER :: P
 
       IF(METALIST%N .EQ. 0) RETURN
@@ -2057,6 +2066,11 @@
           CASE('r', 'f')
             READ(P%ATTVAL, *) RVAL
             ERR = NF90_PUT_ATT(NCID, VARID, P%ATTNAME, RVAL)
+            IF(ERR /= NF90_NOERR) RETURN
+
+          CASE('d')
+            READ(P%ATTVAL, *) DVAL
+            ERR = NF90_PUT_ATT(NCID, VARID, P%ATTNAME, DVAL)
             IF(ERR /= NF90_NOERR) RETURN
 
           CASE('c')

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -931,6 +931,7 @@
       REAL,DIMENSION(:),  ALLOCATABLE    :: LON, LAT, FREQ
       REAL,DIMENSION(:,:),  ALLOCATABLE  :: LON2D, LAT2D, ANGLD2D
 !/RTD      REAL,DIMENSION(:,:),  ALLOCATABLE  :: LON2DEQ, LAT2DEQ
+!/SMC      DOUBLE PRECISION,DIMENSION(:),  ALLOCATABLE    :: LONRGRD, LATRGRD
       ! Make the below allocatable to avoid stack overflow on some machines 
       REAL, ALLOCATABLE       :: X1(:,:), X2(:,:), XX(:,:), XY(:,:),   &
                                  XK(:,:,:), XXK(:,:,:), XYK(:,:,:),    & 
@@ -2069,6 +2070,8 @@
 !/SMC                     ! Regular gridded file
 !/SMC                     IF(.NOT.ALLOCATED(lon)) ALLOCATE(lon(NXO))
 !/SMC                     IF(.NOT.ALLOCATED(lat)) ALLOCATE(lat(NYO))
+!/SMC                     IF(.NOT.ALLOCATED(LONRGRD)) ALLOCATE(LONRGRD(NXO))
+!/SMC                     IF(.NOT.ALLOCATED(LATRGRD)) ALLOCATE(LATRGRD(NYO))
 !/RTD                     ! Intermediate EQUatorial lat/lon arrays for de-rotation
 !/RTD                     ! of rotated pole coordinates:
 !/RTD                     !!IF(.NOT.ALLOCATED(LON2DEQ)) ALLOCATE(LON2DEQ(NXO,NYO))
@@ -2139,12 +2142,15 @@
 !/SMC                    SYD=DBLE(0.00000001d0*DNINT(1d8*(DBLE(DYO)) ))
 !/SMC                    X0D=DBLE(0.00000001d0*DNINT(1d8*(DBLE(SXO)) ))
 !/SMC                    Y0D=DBLE(0.00000001d0*DNINT(1d8*(DBLE(SYO)) ))
+
 !/SMC                    DO i=1,NXO
 !/SMC                      lon(i)=REAL(X0D+SXD*DBLE(i-1))
+!/SMC                      LONRGRD(i)=X0D+SXD*DBLE(i-1)
 !/RTD                      LON2DEQ(i,:) = lon(i)
 !/SMC                    END DO
 !/SMC                    DO i=1,NYO
 !/SMC                      lat(i)=REAL(Y0D+SYD*DBLE(i-1))
+!/SMC                      LATRGRD(i)=Y0D+SYD*DBLE(i-1)
 !/RTD                      LAT2DEQ(:,i) = lat(i)
 !/SMC                    END DO
 !/SMC                    WRITE(STR2,'(F12.7)') DYO
@@ -2293,15 +2299,20 @@
               ! If regular grid
               IF (GTYPE.EQ.RLGTYPE .OR. GTYPE.EQ.SMCTYPE) THEN
                 IF(SMCGRD) THEN ! CB: shelter original code from SMC grid
-!/SMC                  IRET=NF90_PUT_VAR(NCID,VARID(1),LON(:))
-!/SMC                  CALL CHECK_ERR(IRET)
-!/SMC                  IRET=NF90_PUT_VAR(NCID,VARID(2),LAT(:))
-!/SMC                  CALL CHECK_ERR(IRET)
 !/SMC                  IF(SMCOTYPE .EQ. 1) THEN
-!/SMC                    ! For type 1 SCM file also put lat/lons and cell sizes:
+!/SMC                    IRET=NF90_PUT_VAR(NCID,VARID(1),LON(:))
+!/SMC                    CALL CHECK_ERR(IRET)
+!/SMC                    IRET=NF90_PUT_VAR(NCID,VARID(2),LAT(:))
+!/SMC                    CALL CHECK_ERR(IRET)
+!/SMC                    ! For type 1 SMC file also put lat/lons and cell sizes:
 !/SMC                    IRET=NF90_PUT_VAR(NCID,VARID(5),SMCCX)
 !/SMC                    CALL CHECK_ERR(IRET)
 !/SMC                    IRET=NF90_PUT_VAR(NCID,VARID(6),SMCCY)
+!/SMC                    CALL CHECK_ERR(IRET)
+!/SMC                  ELSE ! KS: write regridded SMC coords with double precision
+!/SMC                    IRET=NF90_PUT_VAR(NCID,VARID(1),LONRGRD(:))
+!/SMC                    CALL CHECK_ERR(IRET)
+!/SMC                    IRET=NF90_PUT_VAR(NCID,VARID(2),LATRGRD(:))
 !/SMC                    CALL CHECK_ERR(IRET)
 !/SMC                  ENDIF
                 ELSE ! SMCGRD
@@ -3213,6 +3224,7 @@
       IF (ALLOCATED(LON)) DEALLOCATE(LON, LAT)
       IF (ALLOCATED(LON2D)) DEALLOCATE(LON2D, LAT2D)
 !/RTD      IF (ALLOCATED(LON2DEQ)) DEALLOCATE(LAT2DEQ, LON2DEQ, ANGLD2D)
+!/SMC      IF (ALLOCATED(LONRGRD)) DEALLOCATE(LONRGRD, LATRGRD)
 !
       RETURN
 !
@@ -3350,9 +3362,9 @@
           IF (SMCGRD) THEN
 !/SMC            IF(SMCOTYPE .EQ. 1) THEN
 !/SMC              ! Flat SMC grid - use seapoint dimension:
-!/SMC              IRET = NF90_DEF_VAR(NCID, 'longitude', NF90_DOUBLE, DIMID(2), VARID(1))
+!/SMC              IRET = NF90_DEF_VAR(NCID, 'longitude', NF90_FLOAT, DIMID(2), VARID(1))
 !/SMC              CALL CHECK_ERR(IRET)
-!/SMC              IRET = NF90_DEF_VAR(NCID, 'latitude', NF90_DOUBLE, DIMID(2), VARID(2))
+!/SMC              IRET = NF90_DEF_VAR(NCID, 'latitude', NF90_FLOAT, DIMID(2), VARID(2))
 !/SMC              CALL CHECK_ERR(IRET)
 !/SMC
 !/SMC              ! Latitude and longitude are auxililary variables in type 1 sea point
@@ -3375,6 +3387,7 @@
 !/SMC              IRET = NF90_PUT_ATT(NCID, VARID(6), 'valid_max', 256)
 !/SMC            ELSE
 !/SMC              ! Regridded regular SMC grid - use lon/lat dimensions:
+!/SMC              ! These are now written to netcdf as doubles (K. Stokes)
 !/SMC              IRET = NF90_DEF_VAR(NCID, 'longitude', NF90_DOUBLE, DIMID(2), VARID(1))
 !/SMC              call CHECK_ERR(IRET)
 !/SMC              IRET = NF90_DEF_VAR(NCID, 'latitude', NF90_DOUBLE, DIMID(3), VARID(2))

--- a/model/ftn/ww3_ounf.ftn
+++ b/model/ftn/ww3_ounf.ftn
@@ -2135,10 +2135,10 @@
 !/RTD                                  ANGLD2D(:,1), POLAT, POLON, RTDNY*RTDNX)
 !/SMC                  ELSE
 !/SMC                    ! CB: Regridded SMC data
-!/SMC                    SXD=DBLE(0.000001d0*DNINT(1d6*(DBLE(DXO)) ))
-!/SMC                    SYD=DBLE(0.000001d0*DNINT(1d6*(DBLE(DYO)) ))
-!/SMC                    X0D=DBLE(0.000001d0*DNINT(1d6*(DBLE(SXO)) ))
-!/SMC                    Y0D=DBLE(0.000001d0*DNINT(1d6*(DBLE(SYO)) ))
+!/SMC                    SXD=DBLE(0.00000001d0*DNINT(1d8*(DBLE(DXO)) ))
+!/SMC                    SYD=DBLE(0.00000001d0*DNINT(1d8*(DBLE(DYO)) ))
+!/SMC                    X0D=DBLE(0.00000001d0*DNINT(1d8*(DBLE(SXO)) ))
+!/SMC                    Y0D=DBLE(0.00000001d0*DNINT(1d8*(DBLE(SYO)) ))
 !/SMC                    DO i=1,NXO
 !/SMC                      lon(i)=REAL(X0D+SXD*DBLE(i-1))
 !/RTD                      LON2DEQ(i,:) = lon(i)
@@ -3350,9 +3350,9 @@
           IF (SMCGRD) THEN
 !/SMC            IF(SMCOTYPE .EQ. 1) THEN
 !/SMC              ! Flat SMC grid - use seapoint dimension:
-!/SMC              IRET = NF90_DEF_VAR(NCID, 'longitude', NF90_FLOAT, DIMID(2), VARID(1))
+!/SMC              IRET = NF90_DEF_VAR(NCID, 'longitude', NF90_DOUBLE, DIMID(2), VARID(1))
 !/SMC              CALL CHECK_ERR(IRET)
-!/SMC              IRET = NF90_DEF_VAR(NCID, 'latitude', NF90_FLOAT, DIMID(2), VARID(2))
+!/SMC              IRET = NF90_DEF_VAR(NCID, 'latitude', NF90_DOUBLE, DIMID(2), VARID(2))
 !/SMC              CALL CHECK_ERR(IRET)
 !/SMC
 !/SMC              ! Latitude and longitude are auxililary variables in type 1 sea point
@@ -3374,10 +3374,10 @@
 !/SMC              IRET = NF90_PUT_ATT(NCID, VARID(6), 'valid_min', 1)
 !/SMC              IRET = NF90_PUT_ATT(NCID, VARID(6), 'valid_max', 256)
 !/SMC            ELSE
-!/SMC              ! Regirdded regular SMC grid - use lon/lat dimensions:
-!/SMC              IRET = NF90_DEF_VAR(NCID, 'longitude', NF90_FLOAT, DIMID(2), VARID(1))
+!/SMC              ! Regridded regular SMC grid - use lon/lat dimensions:
+!/SMC              IRET = NF90_DEF_VAR(NCID, 'longitude', NF90_DOUBLE, DIMID(2), VARID(1))
 !/SMC              call CHECK_ERR(IRET)
-!/SMC              IRET = NF90_DEF_VAR(NCID, 'latitude', NF90_FLOAT, DIMID(3), VARID(2))
+!/SMC              IRET = NF90_DEF_VAR(NCID, 'latitude', NF90_DOUBLE, DIMID(3), VARID(2))
 !/SMC              call CHECK_ERR(IRET)
 !/SMC            ENDIF
           ELSE


### PR DESCRIPTION
# Pull Request Summary
This pull request seeks to increase the precision assigned to grid coordinates for regridded SMC grids. This PR will act as a bugfix for UKMO PS46 ww3 code. 

## Description
When creating a re-gridded SMC grid output, ww3_ounf is unable to achieve the requested grid steps as the precision of the variables used to define and write the grid is limited to float precision. This results in an output grid that is truncated at 7 significant decimal digits, with associated rounding errors at the final digit. For grids that approach km-scale resolution more decimal places are required to represent the regular grid steps in the output grid. 

To resolve this issue, the variables that define the re-gridded SMC grid `XO0, YO0, DXO, DYO` have been increased to double precision in w3gridmd.ftn, and double precision is maintained for these and other re-gridding variables within ww3_ounf.ftn. All other output grid types (including SMC type 1) are left with standard float grid coordinates. This is achieved by creation of new `LONRGRD, LATRGRD` variables that are used solely for storing the double precision coordinates for re-gridded SMC grids. The lat and lon coordinates for the regridded SMC grid are then written to Netcdf with double precision. For all other grid types, they remain written to netcdf using float precision.

A related issue is addressed regarding the precision of coordinate reference system (CRS) metadata values written to netcdf, which require a high degree of precision - specifically, double precision is required to represent the 'inverse flattening' crs value. To resolve this, a new metadata type "d" for double precision values is added in w3metamd.ftn and w3ounfmetamd.ftn. This allows "d" type metadata entries to be specified when supplying metadata information to ww3_ounf.

The changes to the source code are not expected to change any computed output values from WW3 except for: 
* the above described lat and lon variables written to netcdf when a re-gridded SMC grid type is requested
* metadata entries specified as type "d"

It is suggested that Andy Saulter and Chris Bunney (just this one time!) review this PR.

### Issue(s) addressed
The issue this PR addresses doesn't have a previous issue number (as far as I'm aware).

### Commit Message
Increased precision of lat and lon output grid coordinates to double precision for re-gridded SMC grids only. Double precision metadata entries have also been enabled when writing output netcdf files.

### Check list  

- [ ] Branch is up to date with the authoritative repository (NOAA-EMC) develop branch. 
- [ ] Checked the [checklist for a developer submitting to develop](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-a-developer-submitting-to-develop). 
- [ ] If a version number update is required, checked the [updating version number](https://github.com/NOAA-EMC/WW3/wiki/Code-Management#checklist-for-updating-version-number) checklist. 
- [ ] If a new feature was added, a regression test for testing the new feature is added. 
 
### Testing
The changes were tested by running WW3 on Met Office global and UK configurations for a 2-day simulation period and checking netcdf output variables (`ncdump -h`,  `ncdump -v longitude`, `ncdump -v latitude`). Before the changes, lon and lat variables were output as floats in netcdf files, with at most 7 significant decimal digits (float precision) and rounding error occurs in the final digit meaning that the grid delta is not maintained throughout. In this example, the requested latitude delta should be 0.0135135 but instead the coordinates are written to netcdf with a rounded delta value that ranges between 0.01351-0.01352:
![image](https://github.com/user-attachments/assets/e24961b6-2ba8-4e55-b185-773d4f6deee9)
![image](https://github.com/user-attachments/assets/c6184e78-34fa-4ed7-bd01-c3944393819f)

While after the changes, lon and lat variables are now output as double precision in netcdf files, and have more than 7 decimal places where needed, and no rounding errors are visible. In this example the grid delta of 0.0135135 is maintained throughout:
![image](https://github.com/user-attachments/assets/c5a06f12-ba7d-406f-96e1-7def401fcd8f)
![image](https://github.com/user-attachments/assets/8f5045f1-70a7-470d-8ff7-cb85c2ad52ea)

It has also been confirmed that these changes do not affect output grids other than re-gridded SMC grids (lat and lon variables remain as float precision).

The addition of metadata type "d" can be seen by the following example, where previously only float ("f") precision could be achieved in metadata entries, depicted here for the `inverse_flattening` crs metadata entry:
![image](https://github.com/user-attachments/assets/e00d1db7-7e10-43f8-9a9f-c8966992280f)

After the changes, double precision output is provided for the `inverse_flattening` crs metadata entry as confirmed by the log output from ww3_ounf:
![image](https://github.com/user-attachments/assets/ee4b92fe-bfa6-47d0-a1bf-2af80002e036)

NOTE - The precision of values written to netcdf files was found to be sensitive to the compiler settings and HPC used. These tests were done using GNU make on the Cray EX HPC at Met Office. Compiler optimisation for ww3_ounf was set to `-O0` as our standard optimisation `-O3` induced rounding errors in the coordinate precisions. 

### Regression tests 
Regression tests have not been conducted for the proposed source code changes, as only output grid coordinates have been affected. However, the change in precision means that bit-for-bit differences are not expected to be achieved in SMC related regression tests as more memory is required to store the double precision output coordinates.
